### PR TITLE
feat(job-machine): add pure state transitions

### DIFF
--- a/dmguard/__init__.py
+++ b/dmguard/__init__.py
@@ -1,0 +1,1 @@
+"""dmguard package."""

--- a/dmguard/job_machine.py
+++ b/dmguard/job_machine.py
@@ -1,0 +1,50 @@
+from enum import Enum
+
+
+class JobStatus(str, Enum):
+    queued = "queued"
+    processing = "processing"
+    done = "done"
+    error = "error"
+    skipped = "skipped"
+
+
+class JobStage(str, Enum):
+    fetch_dm = "fetch_dm"
+    download_media = "download_media"
+    classify = "classify"
+    block = "block"
+
+
+_NEXT_STAGE = {
+    JobStage.fetch_dm: JobStage.download_media,
+    JobStage.download_media: JobStage.classify,
+    JobStage.classify: JobStage.block,
+}
+
+_BACKOFF_SECONDS = {
+    0: 10,
+    1: 60,
+    2: 300,
+}
+
+_TERMINAL_STATUSES = {
+    JobStatus.done,
+    JobStatus.error,
+    JobStatus.skipped,
+}
+
+
+def next_stage(current: JobStage) -> JobStage | None:
+    return _NEXT_STAGE.get(current)
+
+
+def next_backoff_seconds(attempt: int) -> int:
+    try:
+        return _BACKOFF_SECONDS[attempt]
+    except KeyError as exc:
+        raise ValueError(f"max retries exceeded for attempt {attempt}") from exc
+
+
+def is_terminal(status: JobStatus) -> bool:
+    return status in _TERMINAL_STATUSES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ dev = [
     "pytest-playwright>=0.7.2",
     "ruff>=0.15.5",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_job_machine.py
+++ b/tests/test_job_machine.py
@@ -1,0 +1,58 @@
+import pytest
+
+from dmguard.job_machine import (
+    JobStage,
+    JobStatus,
+    is_terminal,
+    next_backoff_seconds,
+    next_stage,
+)
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [
+        (JobStage.fetch_dm, JobStage.download_media),
+        (JobStage.download_media, JobStage.classify),
+        (JobStage.classify, JobStage.block),
+        (JobStage.block, None),
+    ],
+)
+def test_next_stage_returns_expected_stage(
+    current: JobStage, expected: JobStage | None
+) -> None:
+    assert next_stage(current) is expected
+
+
+@pytest.mark.parametrize(
+    ("attempt", "expected"),
+    [
+        (0, 10),
+        (1, 60),
+        (2, 300),
+    ],
+)
+def test_next_backoff_seconds_returns_expected_value(
+    attempt: int, expected: int
+) -> None:
+    assert next_backoff_seconds(attempt) == expected
+
+
+@pytest.mark.parametrize("attempt", [3, 4])
+def test_next_backoff_seconds_raises_after_max_retries(attempt: int) -> None:
+    with pytest.raises(ValueError):
+        next_backoff_seconds(attempt)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (JobStatus.queued, False),
+        (JobStatus.processing, False),
+        (JobStatus.done, True),
+        (JobStatus.error, True),
+        (JobStatus.skipped, True),
+    ],
+)
+def test_is_terminal_returns_expected_value(status: JobStatus, expected: bool) -> None:
+    assert is_terminal(status) is expected


### PR DESCRIPTION
## Summary
- add the pure job status/stage enums and transition helpers for issue #8
- add focused pytest coverage for stage order, terminal status checks, and retry backoff
- configure pytest pythonpath so the local package imports work via the standard pytest entry point

## Testing
- uv run pytest

Closes #8