### PR TITLE
feat(paths): add package structure and path policy

### DIFF
--- a/dmguard/__init__.py
+++ b/dmguard/__init__.py
@@ -1,0 +1,1 @@
+"""dmguard package."""

--- a/dmguard/paths.py
+++ b/dmguard/paths.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+import os
+import sys
+
+
+WINDOWS_PROGRAM_FILES_DIR = Path("C:/Program Files/XDMModerator")
+WINDOWS_PROGRAM_DATA_DIR = Path("C:/ProgramData/XDMModerator")
+
+
+@dataclass(frozen=True)
+class ResolvedPaths:
+    program_files_dir: Path
+    program_data_dir: Path
+    db_path: Path
+    config_path: Path
+    secrets_path: Path
+    logs_dir: Path
+    tmp_dir: Path
+
+
+def resolve_paths(
+    *,
+    platform: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> ResolvedPaths:
+    current_platform = platform or sys.platform
+    current_env = env or os.environ
+
+    program_files_dir = WINDOWS_PROGRAM_FILES_DIR
+    program_data_dir = WINDOWS_PROGRAM_DATA_DIR
+
+    if not current_platform.startswith("win"):
+        app_root = current_env.get("DMGUARD_APP_ROOT")
+        data_root = current_env.get("DMGUARD_DATA_ROOT")
+
+        if app_root:
+            program_files_dir = Path(app_root)
+
+        if data_root:
+            program_data_dir = Path(data_root)
+
+    return ResolvedPaths(
+        program_files_dir=program_files_dir,
+        program_data_dir=program_data_dir,
+        db_path=program_data_dir / "state.db",
+        config_path=program_data_dir / "config.yaml",
+        secrets_path=program_data_dir / "secrets.bin",
+        logs_dir=program_data_dir / "logs",
+        tmp_dir=program_data_dir / "tmp",
+    )
+
+
+_RESOLVED_PATHS = resolve_paths()
+
+PROGRAM_FILES_DIR = _RESOLVED_PATHS.program_files_dir
+PROGRAM_DATA_DIR = _RESOLVED_PATHS.program_data_dir
+DB_PATH = _RESOLVED_PATHS.db_path
+CONFIG_PATH = _RESOLVED_PATHS.config_path
+SECRETS_PATH = _RESOLVED_PATHS.secrets_path
+LOGS_DIR = _RESOLVED_PATHS.logs_dir
+TMP_DIR = _RESOLVED_PATHS.tmp_dir
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DB_PATH",
+    "LOGS_DIR",
+    "PROGRAM_DATA_DIR",
+    "PROGRAM_FILES_DIR",
+    "ResolvedPaths",
+    "SECRETS_PATH",
+    "TMP_DIR",
+    "resolve_paths",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ dev = [
     "pytest-playwright>=0.7.2",
     "ruff>=0.15.5",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,83 @@
+import importlib
+from pathlib import Path
+
+
+def test_resolve_paths_windows_defaults():
+    from dmguard.paths import resolve_paths
+
+    paths = resolve_paths(platform="win32", env={})
+
+    assert paths.program_files_dir == Path("C:/Program Files/XDMModerator")
+    assert paths.program_data_dir == Path("C:/ProgramData/XDMModerator")
+    assert paths.db_path == Path("C:/ProgramData/XDMModerator/state.db")
+    assert paths.config_path == Path("C:/ProgramData/XDMModerator/config.yaml")
+    assert paths.secrets_path == Path("C:/ProgramData/XDMModerator/secrets.bin")
+    assert paths.logs_dir == Path("C:/ProgramData/XDMModerator/logs")
+    assert paths.tmp_dir == Path("C:/ProgramData/XDMModerator/tmp")
+
+
+def test_resolve_paths_non_windows_env_override():
+    from dmguard.paths import resolve_paths
+
+    paths = resolve_paths(
+        platform="darwin",
+        env={
+            "DMGUARD_APP_ROOT": "/tmp/dmguard-app",
+            "DMGUARD_DATA_ROOT": "/tmp/dmguard-data",
+        },
+    )
+
+    assert paths.program_files_dir == Path("/tmp/dmguard-app")
+    assert paths.program_data_dir == Path("/tmp/dmguard-data")
+    assert paths.db_path == Path("/tmp/dmguard-data/state.db")
+    assert paths.config_path == Path("/tmp/dmguard-data/config.yaml")
+    assert paths.secrets_path == Path("/tmp/dmguard-data/secrets.bin")
+    assert paths.logs_dir == Path("/tmp/dmguard-data/logs")
+    assert paths.tmp_dir == Path("/tmp/dmguard-data/tmp")
+
+
+def test_resolved_paths_are_path_instances():
+    from dmguard.paths import resolve_paths
+
+    paths = resolve_paths(platform="win32", env={})
+
+    assert isinstance(paths.program_files_dir, Path)
+    assert isinstance(paths.program_data_dir, Path)
+    assert isinstance(paths.db_path, Path)
+    assert isinstance(paths.config_path, Path)
+    assert isinstance(paths.secrets_path, Path)
+    assert isinstance(paths.logs_dir, Path)
+    assert isinstance(paths.tmp_dir, Path)
+
+
+def test_exported_path_constants_are_path_instances():
+    from dmguard import paths
+
+    assert isinstance(paths.PROGRAM_FILES_DIR, Path)
+    assert isinstance(paths.PROGRAM_DATA_DIR, Path)
+    assert isinstance(paths.DB_PATH, Path)
+    assert isinstance(paths.CONFIG_PATH, Path)
+    assert isinstance(paths.SECRETS_PATH, Path)
+    assert isinstance(paths.LOGS_DIR, Path)
+    assert isinstance(paths.TMP_DIR, Path)
+
+
+def test_exported_path_constants_respect_non_windows_env_override(monkeypatch):
+    from dmguard import paths
+
+    with monkeypatch.context() as context:
+        context.setattr(paths.sys, "platform", "darwin")
+        context.setenv("DMGUARD_APP_ROOT", "/tmp/dmguard-app")
+        context.setenv("DMGUARD_DATA_ROOT", "/tmp/dmguard-data")
+
+        reloaded_paths = importlib.reload(paths)
+
+        assert reloaded_paths.PROGRAM_FILES_DIR == Path("/tmp/dmguard-app")
+        assert reloaded_paths.PROGRAM_DATA_DIR == Path("/tmp/dmguard-data")
+        assert reloaded_paths.DB_PATH == Path("/tmp/dmguard-data/state.db")
+        assert reloaded_paths.CONFIG_PATH == Path("/tmp/dmguard-data/config.yaml")
+        assert reloaded_paths.SECRETS_PATH == Path("/tmp/dmguard-data/secrets.bin")
+        assert reloaded_paths.LOGS_DIR == Path("/tmp/dmguard-data/logs")
+        assert reloaded_paths.TMP_DIR == Path("/tmp/dmguard-data/tmp")
+
+    importlib.reload(paths)


### PR DESCRIPTION
## Summary
- add the dmguard package with a resolver-backed paths module
- export Windows path constants with non-Windows env overrides for testability
- add targeted pytest coverage and configure pytest to import the source tree directly

## Testing
- uv run pytest tests/test_paths.py
- uv run pytest
- uv run python -c "from dmguard.paths import PROGRAM_DATA_DIR, DB_PATH; print(PROGRAM_DATA_DIR); print(DB_PATH)"

Closes #1