### PR TITLE
feat(logging): add logging bootstrap

### DIFF
--- a/dmguard/logging_setup.py
+++ b/dmguard/logging_setup.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import logging
+
+from dmguard.config import AppConfig
+from dmguard.paths import LOGS_DIR
+
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+
+
+def resolve_log_level(log_level: str) -> int:
+    try:
+        return logging.getLevelNamesMapping()[log_level.upper()]
+    except KeyError as error:
+        raise ValueError(f"Unsupported log level: {log_level}") from error
+
+
+def reset_logger_handlers(logger: logging.Logger) -> None:
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+
+def configure_file_logger(name: str, log_path: Path, level: int) -> logging.Logger:
+    logger = logging.getLogger(name)
+    reset_logger_handlers(logger)
+
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    return logger
+
+
+def setup_logging(config: AppConfig) -> None:
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
+    level = resolve_log_level(config.log_level)
+
+    configure_file_logger("dmguard", LOGS_DIR / "dmguard.log", level)
+    configure_file_logger("classifier", LOGS_DIR / "classifier.log", level)
+
+
+__all__ = ["setup_logging"]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -15,7 +15,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 - [x] #1 Package structure + path policy — deps: _none_
 - [x] #2 Config loader (Pydantic v2) — deps: #1
-- [ ] #3 Logging bootstrap — deps: #1
+- [x] #3 Logging bootstrap — deps: #1
 - [ ] #4 FastAPI app skeleton — deps: #1, #2, #3
 
 ## Milestone 2 — Database

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,125 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from dmguard.config import AppConfig
+
+
+def build_config(*, log_level: str = "INFO") -> AppConfig:
+    return AppConfig(
+        debug=False,
+        log_level=log_level,
+        public_hostname="dmguard.duckdns.org",
+        acme_email="ori@example.com",
+    )
+
+
+def clear_logger(name: str) -> None:
+    logger = logging.getLogger(name)
+
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
+
+
+@pytest.fixture(autouse=True)
+def reset_named_loggers() -> None:
+    clear_logger("dmguard")
+    clear_logger("classifier")
+
+    yield
+
+    clear_logger("dmguard")
+    clear_logger("classifier")
+
+
+def flush_logger_handlers(name: str) -> None:
+    for handler in logging.getLogger(name).handlers:
+        handler.flush()
+
+
+def test_setup_logging_creates_log_files_and_named_loggers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import dmguard.logging_setup as logging_setup
+
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOGS_DIR", logs_dir)
+
+    logging_setup.setup_logging(build_config())
+
+    assert logs_dir.is_dir()
+    assert (logs_dir / "dmguard.log").exists()
+    assert (logs_dir / "classifier.log").exists()
+    assert logging.getLogger("dmguard").name == "dmguard"
+    assert logging.getLogger("classifier").name == "classifier"
+
+
+def test_setup_logging_applies_configured_log_level(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import dmguard.logging_setup as logging_setup
+
+    monkeypatch.setattr(logging_setup, "LOGS_DIR", tmp_path / "logs")
+
+    logging_setup.setup_logging(build_config(log_level="WARNING"))
+
+    assert logging.getLogger("dmguard").level == logging.WARNING
+    assert logging.getLogger("classifier").level == logging.WARNING
+
+
+def test_setup_logging_routes_messages_to_separate_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import dmguard.logging_setup as logging_setup
+
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOGS_DIR", logs_dir)
+
+    logging_setup.setup_logging(build_config())
+
+    dmguard_logger = logging.getLogger("dmguard")
+    classifier_logger = logging.getLogger("classifier")
+
+    dmguard_logger.info("dmguard message")
+    classifier_logger.info("classifier message")
+
+    flush_logger_handlers("dmguard")
+    flush_logger_handlers("classifier")
+
+    dmguard_log = (logs_dir / "dmguard.log").read_text(encoding="utf-8")
+    classifier_log = (logs_dir / "classifier.log").read_text(encoding="utf-8")
+
+    assert "dmguard message" in dmguard_log
+    assert "classifier message" not in dmguard_log
+    assert "classifier message" in classifier_log
+    assert "dmguard message" not in classifier_log
+
+
+def test_setup_logging_replaces_existing_handlers_on_repeat_setup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import dmguard.logging_setup as logging_setup
+
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOGS_DIR", logs_dir)
+
+    logging_setup.setup_logging(build_config())
+    logging_setup.setup_logging(build_config())
+
+    dmguard_logger = logging.getLogger("dmguard")
+    classifier_logger = logging.getLogger("classifier")
+
+    assert len(dmguard_logger.handlers) == 1
+    assert len(classifier_logger.handlers) == 1
+
+    dmguard_logger.info("written once")
+    flush_logger_handlers("dmguard")
+
+    dmguard_log = (logs_dir / "dmguard.log").read_text(encoding="utf-8")
+
+    assert dmguard_log.count("written once") == 1


### PR DESCRIPTION
## Summary
- add logging bootstrap for the dmguard and classifier named loggers
- add tests for log file creation, log level handling, routing, and repeated setup
- mark issue #3 complete in issues_todo.md

## Testing
- uv run pytest tests/test_logging_setup.py tests/test_config.py tests/test_paths.py tests/test_job_machine.py

Closes #3