### PR TITLE
feat(db): add sqlite connection factory

### DIFF
--- a/dmguard/db.py
+++ b/dmguard/db.py
@@ -1,0 +1,21 @@
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiosqlite
+
+
+@asynccontextmanager
+async def get_connection(db_path: Path) -> AsyncIterator[aiosqlite.Connection]:
+    connection = await aiosqlite.connect(str(db_path))
+
+    try:
+        await connection.execute("PRAGMA foreign_keys = ON")
+        await connection.execute("PRAGMA journal_mode = WAL")
+        await connection.execute("PRAGMA busy_timeout = 5000")
+        yield connection
+    finally:
+        await connection.close()
+
+
+__all__ = ["get_connection"]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -20,7 +20,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 2 — Database
 
-- [ ] #5 DB connection management — deps: #1
+- [x] #5 DB connection management — deps: #1
 - [ ] #6 Schema DDL + indexes — deps: #5
 - [ ] #7 Repository layer — deps: #6
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,59 @@
+import asyncio
+from pathlib import Path
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+async def insert_and_read_value(db_path: Path) -> str:
+    from dmguard.db import get_connection
+
+    async with get_connection(db_path) as connection:
+        await connection.execute("CREATE TABLE sample (value TEXT NOT NULL)")
+        await connection.execute("INSERT INTO sample (value) VALUES ('ok')")
+        await connection.commit()
+
+    async with get_connection(db_path) as connection:
+        cursor = await connection.execute("SELECT value FROM sample")
+        row = await cursor.fetchone()
+
+    return row[0]
+
+
+async def fetch_pragma_value(db_path: Path, pragma_name: str):
+    from dmguard.db import get_connection
+
+    async with get_connection(db_path) as connection:
+        cursor = await connection.execute(f"PRAGMA {pragma_name}")
+        return await cursor.fetchone()
+
+
+def test_get_connection_opens_and_closes_cleanly(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    assert run(insert_and_read_value(db_path)) == "ok"
+
+
+def test_get_connection_enables_foreign_keys(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    pragma_row = run(fetch_pragma_value(db_path, "foreign_keys"))
+
+    assert pragma_row == (1,)
+
+
+def test_get_connection_uses_wal_journal_mode(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    pragma_row = run(fetch_pragma_value(db_path, "journal_mode"))
+
+    assert pragma_row == ("wal",)
+
+
+def test_get_connection_sets_busy_timeout(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    pragma_row = run(fetch_pragma_value(db_path, "busy_timeout"))
+
+    assert pragma_row == (5000,)


### PR DESCRIPTION
## Summary
- add an async sqlite connection context manager in `dmguard.db`
- enable foreign keys, WAL mode, and a 5000 ms busy timeout on every connection
- add focused tests for connection lifecycle and pragma configuration

## Testing
- uv run pytest tests/test_db.py
- uv run pytest

Closes #5