### PR TITLE
feat(secrets): add file-backed secret store

### DIFF
--- a/dmguard/secrets.py
+++ b/dmguard/secrets.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+import json
+
+from dmguard.paths import SECRETS_PATH
+
+
+SECRET_KEYS = frozenset(
+    {
+        "x_access_token",
+        "x_refresh_token",
+        "x_consumer_secret",
+        "x_app_bearer",
+        "hf_token",
+    }
+)
+
+
+class MissingSecretError(KeyError):
+    """Raised when a requested secret is not available."""
+
+
+class SecretStore(ABC):
+    @abstractmethod
+    def get(self, key: str) -> str:
+        raise NotImplementedError
+
+
+class FileSecretStore(SecretStore):
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or SECRETS_PATH
+
+    def get(self, key: str) -> str:
+        if key not in SECRET_KEYS:
+            raise MissingSecretError(f"Unknown secret key: {key}")
+
+        secrets = self._load_secrets()
+
+        try:
+            value = secrets[key]
+        except KeyError as exc:
+            raise MissingSecretError(f"Missing secret value for key: {key}") from exc
+
+        if not isinstance(value, str):
+            raise MissingSecretError(f"Secret value for key must be a string: {key}")
+
+        return value
+
+    def _load_secrets(self) -> dict[str, object]:
+        with self._path.open(encoding="utf-8") as secrets_file:
+            return json.load(secrets_file)
+
+
+__all__ = ["FileSecretStore", "MissingSecretError", "SECRET_KEYS", "SecretStore"]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -46,7 +46,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 6 — X API Client
 
-- [ ] #19 Secrets loader interface — deps: #1
+- [x] #19 Secrets loader interface — deps: #1
 - [ ] #20 X HTTP client — deps: #19
 - [ ] #21 DM lookup client + DTOs — deps: #20
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+
+
+def write_secrets_file(tmp_path: Path, content: str) -> Path:
+    secrets_path = tmp_path / "secrets.bin"
+    secrets_path.write_text(content, encoding="utf-8")
+    return secrets_path
+
+
+def test_file_secret_store_get_returns_expected_value(tmp_path: Path) -> None:
+    from dmguard.secrets import FileSecretStore
+
+    secrets_path = write_secrets_file(
+        tmp_path,
+        """
+{
+  "x_access_token": "access-token",
+  "x_refresh_token": "refresh-token",
+  "x_consumer_secret": "consumer-secret",
+  "x_app_bearer": "app-bearer",
+  "hf_token": "hf-token"
+}
+""".strip(),
+    )
+
+    store = FileSecretStore(secrets_path)
+
+    assert store.get("x_access_token") == "access-token"
+    assert store.get("hf_token") == "hf-token"
+
+
+def test_file_secret_store_raises_missing_secret_error_for_unknown_key(
+    tmp_path: Path,
+) -> None:
+    from dmguard.secrets import FileSecretStore, MissingSecretError
+
+    secrets_path = write_secrets_file(
+        tmp_path,
+        """
+{
+  "x_access_token": "access-token",
+  "x_refresh_token": "refresh-token",
+  "x_consumer_secret": "consumer-secret",
+  "x_app_bearer": "app-bearer",
+  "hf_token": "hf-token"
+}
+""".strip(),
+    )
+
+    store = FileSecretStore(secrets_path)
+
+    with pytest.raises(MissingSecretError) as exc_info:
+        store.get("not-a-real-key")
+
+    assert "not-a-real-key" in str(exc_info.value)
+
+
+def test_file_secret_store_raises_file_not_found_for_missing_file(
+    tmp_path: Path,
+) -> None:
+    from dmguard.secrets import FileSecretStore
+
+    missing_path = tmp_path / "missing-secrets.bin"
+    store = FileSecretStore(missing_path)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        store.get("x_access_token")
+
+    assert str(missing_path) in str(exc_info.value)
+
+
+def test_file_secret_store_uses_default_secrets_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dmguard import secrets
+
+    secrets_path = write_secrets_file(
+        tmp_path,
+        """
+{
+  "x_access_token": "access-token",
+  "x_refresh_token": "refresh-token",
+  "x_consumer_secret": "consumer-secret",
+  "x_app_bearer": "app-bearer",
+  "hf_token": "hf-token"
+}
+""".strip(),
+    )
+
+    monkeypatch.setattr(secrets, "SECRETS_PATH", secrets_path)
+
+    store = secrets.FileSecretStore()
+
+    assert store.get("x_consumer_secret") == "consumer-secret"

--- a/todo.md
+++ b/todo.md
@@ -180,7 +180,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] Proactive token refresh
 - [x] Token expiry metadata stored in SQLite
 - [x] Refresh failure marks system misconfigured
-- [ ] Implement secret loader
+- [x] Implement secret loader
 - [ ] Implement X API client
 - [ ] Implement DM lookup DTO parsing
 - [ ] Implement proactive refresh


### PR DESCRIPTION
## Summary
- add a file-backed SecretStore implementation for runtime secrets loading
- add focused tests for valid lookup, unknown keys, missing files, and default path behavior
- mark issue #19 and the matching todo item complete after verification

## Testing
- uv run pytest

Closes #19