### PR TITLE
feat(classifier): add fake classifier contract

### DIFF
--- a/dmguard/classifier_contract.py
+++ b/dmguard/classifier_contract.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+ClassifierMode = Literal["image", "video"]
+ClassifierPolicy = Literal["violence_gore"]
+
+
+class ClassifierRequest(BaseModel):
+    mode: ClassifierMode
+    files: list[str] = Field(min_length=1)
+    policy: ClassifierPolicy
+
+
+class ClassifierResponse(BaseModel):
+    policy: ClassifierPolicy
+    yes_prob: float
+    trigger_frame_index: int | None = None
+    trigger_time_sec: float | None = None
+
+
+def load_classifier_request(path: Path) -> ClassifierRequest:
+    return ClassifierRequest.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "ClassifierMode",
+    "ClassifierPolicy",
+    "ClassifierRequest",
+    "ClassifierResponse",
+    "load_classifier_request",
+]

--- a/dmguard/classifier_fake.py
+++ b/dmguard/classifier_fake.py
@@ -1,0 +1,43 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Sequence
+import sys
+
+from dmguard.classifier_contract import ClassifierResponse, load_classifier_request
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument("input_path", type=Path)
+
+    force_group = parser.add_mutually_exclusive_group()
+    force_group.add_argument("--force-safe", action="store_true")
+    force_group.add_argument("--force-unsafe", action="store_true")
+
+    return parser
+
+
+def build_response(input_path: Path, *, force_unsafe: bool) -> ClassifierResponse:
+    request = load_classifier_request(input_path)
+
+    response = ClassifierResponse(
+        policy=request.policy,
+        yes_prob=0.99 if force_unsafe else 0.01,
+    )
+
+    if request.mode == "video" and force_unsafe:
+        response.trigger_frame_index = 0
+        response.trigger_time_sec = 1.0
+
+    return response
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    response = build_response(args.input_path, force_unsafe=args.force_unsafe)
+    print(response.model_dump_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -58,7 +58,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 8 — Classifier
 
-- [ ] #25 Classifier subprocess contract + fake entrypoint — deps: #1
+- [x] #25 Classifier subprocess contract + fake entrypoint — deps: #1
 - [ ] #26 Subprocess runner + timeout — deps: #25
 - [ ] #27 Selftest CLI — deps: #26
 

--- a/tests/test_classifier_contract.py
+++ b/tests/test_classifier_contract.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import json
+
+import pytest
+from pydantic import ValidationError
+
+
+def write_classifier_input(tmp_path: Path, payload: dict[str, object]) -> Path:
+    input_path = tmp_path / "classifier-input.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+    return input_path
+
+
+def test_classifier_request_parses_valid_image_payload(tmp_path: Path) -> None:
+    from dmguard.classifier_contract import ClassifierRequest
+
+    input_path = write_classifier_input(
+        tmp_path,
+        {
+            "mode": "image",
+            "files": ["frame-1.jpg"],
+            "policy": "violence_gore",
+        },
+    )
+
+    request = ClassifierRequest.model_validate_json(
+        input_path.read_text(encoding="utf-8")
+    )
+
+    assert request.mode == "image"
+    assert request.files == ["frame-1.jpg"]
+    assert request.policy == "violence_gore"
+
+
+def test_classifier_request_rejects_empty_files_list(tmp_path: Path) -> None:
+    from dmguard.classifier_contract import ClassifierRequest
+
+    input_path = write_classifier_input(
+        tmp_path,
+        {
+            "mode": "video",
+            "files": [],
+            "policy": "violence_gore",
+        },
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        ClassifierRequest.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+    assert "files" in str(exc_info.value)
+
+
+def test_classifier_response_requires_known_policy() -> None:
+    from dmguard.classifier_contract import ClassifierResponse
+
+    with pytest.raises(ValidationError) as exc_info:
+        ClassifierResponse.model_validate(
+            {
+                "policy": "unknown_policy",
+                "yes_prob": 0.5,
+                "trigger_frame_index": None,
+                "trigger_time_sec": None,
+            }
+        )
+
+    assert "policy" in str(exc_info.value)

--- a/tests/test_classifier_fake.py
+++ b/tests/test_classifier_fake.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import json
+
+
+def write_classifier_input(
+    tmp_path: Path,
+    *,
+    mode: str,
+    files: list[str],
+    policy: str = "violence_gore",
+) -> Path:
+    input_path = tmp_path / "classifier-input.json"
+    input_path.write_text(
+        json.dumps({"mode": mode, "files": files, "policy": policy}),
+        encoding="utf-8",
+    )
+    return input_path
+
+
+def test_classifier_fake_force_safe_writes_valid_json_to_stdout(
+    tmp_path: Path, capsys
+) -> None:
+    from dmguard.classifier_contract import ClassifierResponse
+    from dmguard.classifier_fake import main
+
+    input_path = write_classifier_input(tmp_path, mode="image", files=["image.jpg"])
+
+    exit_code = main([str(input_path), "--force-safe"])
+
+    captured = capsys.readouterr()
+    response = ClassifierResponse.model_validate_json(captured.out)
+
+    assert exit_code == 0
+    assert response.yes_prob == 0.01
+    assert response.trigger_frame_index is None
+    assert response.trigger_time_sec is None
+
+
+def test_classifier_fake_force_unsafe_video_includes_trigger_metadata(
+    tmp_path: Path, capsys
+) -> None:
+    from dmguard.classifier_contract import ClassifierResponse
+    from dmguard.classifier_fake import main
+
+    input_path = write_classifier_input(
+        tmp_path,
+        mode="video",
+        files=["frame-1.jpg", "frame-2.jpg"],
+    )
+
+    exit_code = main([str(input_path), "--force-unsafe"])
+
+    captured = capsys.readouterr()
+    response = ClassifierResponse.model_validate_json(captured.out)
+
+    assert exit_code == 0
+    assert response.yes_prob == 0.99
+    assert response.trigger_frame_index == 0
+    assert response.trigger_time_sec == 1.0
+
+
+def test_classifier_fake_image_mode_keeps_trigger_fields_null(
+    tmp_path: Path, capsys
+) -> None:
+    from dmguard.classifier_contract import ClassifierResponse
+    from dmguard.classifier_fake import main
+
+    input_path = write_classifier_input(tmp_path, mode="image", files=["image.jpg"])
+
+    exit_code = main([str(input_path), "--force-unsafe"])
+
+    captured = capsys.readouterr()
+    response = ClassifierResponse.model_validate_json(captured.out)
+
+    assert exit_code == 0
+    assert response.trigger_frame_index is None
+    assert response.trigger_time_sec is None

--- a/todo.md
+++ b/todo.md
@@ -219,11 +219,11 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] `--force-unsafe` returns 0.99
 - [x] `--force-unsafe` video metadata uses trigger frame/time
 - [x] Classifier stderr is captured and written to `classifier.log`
-- [ ] Implement subprocess contract
-- [ ] Implement fake classifier mode for early tests
+- [x] Implement subprocess contract
+- [x] Implement fake classifier mode for early tests
 - [ ] Integrate real ShieldGemma inference
 - [ ] Implement selftest CLI
-- [ ] Add classifier contract tests
+- [x] Add classifier contract tests
 
 ---
 


### PR DESCRIPTION
## Summary
- add typed classifier request/response models for the JSON IPC boundary
- add a deterministic fake classifier entrypoint for image and video payloads
- mark issue #25 and the verified classifier checklist items complete

## Testing
- uv run pytest

Closes #25