### PR TITLE
feat(traefik): add template renderer

### DIFF
--- a/dmguard/templates.py
+++ b/dmguard/templates.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from typing import Final, Mapping
+import re
+
+
+PLACEHOLDER_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{\{([^{}]+)\}\}")
+SUPPORTED_PLACEHOLDERS: Final[frozenset[str]] = frozenset(
+    {
+        "PUBLIC_HOSTNAME",
+        "BACKEND_URL",
+        "DEBUG_DASHBOARD_PORT",
+        "ACME_EMAIL",
+        "ACME_STORAGE_PATH",
+        "TRAEFIK_LOG_PATH",
+    }
+)
+
+
+class UnknownPlaceholderError(ValueError):
+    pass
+
+
+class MissingPlaceholderValueError(ValueError):
+    pass
+
+
+def render_template(tpl_path: Path, vars: Mapping[str, object]) -> str:
+    template = tpl_path.read_text()
+    placeholders = [match.group(1) for match in PLACEHOLDER_PATTERN.finditer(template)]
+
+    unknown_placeholders = sorted(
+        {
+            placeholder
+            for placeholder in placeholders
+            if placeholder not in SUPPORTED_PLACEHOLDERS
+        }
+    )
+    if unknown_placeholders:
+        unknown_placeholder = unknown_placeholders[0]
+        raise UnknownPlaceholderError(f"Unknown placeholder: {unknown_placeholder}")
+
+    missing_placeholders = sorted(
+        {
+            placeholder
+            for placeholder in placeholders
+            if placeholder in SUPPORTED_PLACEHOLDERS and placeholder not in vars
+        }
+    )
+    if missing_placeholders:
+        missing_placeholder = missing_placeholders[0]
+        raise MissingPlaceholderValueError(
+            f"Missing placeholder value: {missing_placeholder}"
+        )
+
+    def replace_placeholder(match: re.Match[str]) -> str:
+        placeholder = match.group(1)
+        return str(vars[placeholder])
+
+    return PLACEHOLDER_PATTERN.sub(replace_placeholder, template)
+
+
+__all__ = [
+    "MissingPlaceholderValueError",
+    "SUPPORTED_PLACEHOLDERS",
+    "UnknownPlaceholderError",
+    "render_template",
+]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -76,7 +76,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 11 — Traefik + Services
 
-- [ ] #34 Template rendering — deps: #1
+- [x] #34 Template rendering — deps: #1
 - [ ] #35 Atomic routes.yml write + service definitions — deps: #34
 
 ## Milestone 12 — Setup Orchestration

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import pytest
+
+
+def write_template(path: Path, content: str) -> Path:
+    path.write_text(content)
+    return path
+
+
+def template_vars() -> dict[str, str]:
+    return {
+        "PUBLIC_HOSTNAME": "example.duckdns.org",
+        "BACKEND_URL": "http://127.0.0.1:8080",
+        "DEBUG_DASHBOARD_PORT": "8081",
+        "ACME_EMAIL": "ops@example.com",
+        "ACME_STORAGE_PATH": "C:/ProgramData/XDMModerator/traefik/acme.json",
+        "TRAEFIK_LOG_PATH": "C:/ProgramData/XDMModerator/logs/traefik.log",
+    }
+
+
+def test_render_template_substitutes_supported_placeholders(tmp_path: Path) -> None:
+    from dmguard.templates import render_template
+
+    template_path = write_template(
+        tmp_path / "traefik-static.yml.tpl",
+        "\n".join(
+            [
+                "host={{PUBLIC_HOSTNAME}}",
+                "backend={{BACKEND_URL}}",
+                "dashboard={{DEBUG_DASHBOARD_PORT}}",
+                "email={{ACME_EMAIL}}",
+                "storage={{ACME_STORAGE_PATH}}",
+                "log={{TRAEFIK_LOG_PATH}}",
+                "repeat={{PUBLIC_HOSTNAME}}",
+            ]
+        ),
+    )
+
+    rendered = render_template(template_path, template_vars())
+
+    assert rendered == "\n".join(
+        [
+            "host=example.duckdns.org",
+            "backend=http://127.0.0.1:8080",
+            "dashboard=8081",
+            "email=ops@example.com",
+            "storage=C:/ProgramData/XDMModerator/traefik/acme.json",
+            "log=C:/ProgramData/XDMModerator/logs/traefik.log",
+            "repeat=example.duckdns.org",
+        ]
+    )
+
+
+def test_render_template_raises_for_unknown_placeholder(tmp_path: Path) -> None:
+    from dmguard.templates import UnknownPlaceholderError, render_template
+
+    template_path = write_template(
+        tmp_path / "traefik-static.yml.tpl",
+        "host={{PUBLIC_HOSTNAME}}\ninvalid={{UNKNOWN_KEY}}",
+    )
+
+    with pytest.raises(UnknownPlaceholderError, match="UNKNOWN_KEY"):
+        render_template(template_path, template_vars())
+
+
+def test_render_template_raises_for_missing_placeholder_value(tmp_path: Path) -> None:
+    from dmguard.templates import MissingPlaceholderValueError, render_template
+
+    template_path = write_template(
+        tmp_path / "traefik-static.yml.tpl",
+        "host={{PUBLIC_HOSTNAME}}\nemail={{ACME_EMAIL}}",
+    )
+    vars_without_email = template_vars()
+    del vars_without_email["ACME_EMAIL"]
+
+    with pytest.raises(MissingPlaceholderValueError, match="ACME_EMAIL"):
+        render_template(template_path, vars_without_email)
+
+
+def test_routes_templates_render_independently(tmp_path: Path) -> None:
+    from dmguard.templates import render_template
+
+    normal_template = write_template(
+        tmp_path / "routes-normal.yml.tpl",
+        "rule=Host(`{{PUBLIC_HOSTNAME}}`)\nservice={{BACKEND_URL}}",
+    )
+    debug_template = write_template(
+        tmp_path / "routes-debug.yml.tpl",
+        "dashboard=:{{DEBUG_DASHBOARD_PORT}}\nlog={{TRAEFIK_LOG_PATH}}",
+    )
+
+    rendered_normal = render_template(normal_template, template_vars())
+    rendered_debug = render_template(debug_template, template_vars())
+
+    assert (
+        rendered_normal
+        == "rule=Host(`example.duckdns.org`)\nservice=http://127.0.0.1:8080"
+    )
+    assert (
+        rendered_debug
+        == "dashboard=:8081\nlog=C:/ProgramData/XDMModerator/logs/traefik.log"
+    )
+
+
+def test_render_template_ignores_unused_values(tmp_path: Path) -> None:
+    from dmguard.templates import render_template
+
+    template_path = write_template(
+        tmp_path / "routes-normal.yml.tpl",
+        "rule=Host(`{{PUBLIC_HOSTNAME}}`)",
+    )
+    values = template_vars()
+    values["UNUSED_VALUE"] = "ignored"
+
+    rendered = render_template(template_path, values)
+
+    assert rendered == "rule=Host(`example.duckdns.org`)"


### PR DESCRIPTION
## Summary
- add strict Traefik template rendering for the agreed placeholder set
- add focused tests for substitution, unknown placeholders, missing values, and separate route templates
- mark issue #34 done in issues_todo.md

Closes #34