### PR TITLE
feat(setup): add setup state persistence

### DIFF
--- a/dmguard/setup_state.py
+++ b/dmguard/setup_state.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Literal
+import json
+import os
+
+from pydantic import BaseModel
+
+
+class StageStatus(BaseModel):
+    status: Literal["pending", "running", "done", "failed", "skipped"]
+    started_at: str | None
+    finished_at: str | None
+    artifacts: list[str]
+
+
+class SetupState(BaseModel):
+    last_command: str
+    effective_args: dict[str, object]
+    stages: dict[str, StageStatus]
+    updated_at: str
+
+
+def load_setup_state(path: Path) -> SetupState | None:
+    if not path.exists():
+        return None
+
+    with path.open(encoding="utf-8") as state_file:
+        raw_state = json.load(state_file)
+
+    return SetupState.model_validate(raw_state)
+
+
+def save_setup_state(state: SetupState, path: Path) -> None:
+    payload = json.dumps(state.model_dump(mode="json"), indent=2)
+
+    with NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temp_file:
+        temp_file.write(payload)
+        temp_path = Path(temp_file.name)
+
+    os.replace(temp_path, path)
+
+
+__all__ = ["SetupState", "StageStatus", "load_setup_state", "save_setup_state"]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -81,7 +81,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 12 — Setup Orchestration
 
-- [ ] #36 Setup state machine + setup_state.json — deps: #1
+- [x] #36 Setup state machine + setup_state.json — deps: #1
 - [ ] #37 Stage invalidation + verbose output — deps: #36
 - [ ] #38 Setup.log writer + secret redaction — deps: #36
 

--- a/tests/test_setup_state.py
+++ b/tests/test_setup_state.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+
+def make_setup_state():
+    from dmguard.setup_state import SetupState, StageStatus
+
+    return SetupState(
+        last_command="setup --verbose",
+        effective_args={
+            "debug": True,
+            "public_hostname": "dmguard.duckdns.org",
+        },
+        stages={
+            "preflight": StageStatus(
+                status="done",
+                started_at="2026-03-11T12:00:00Z",
+                finished_at="2026-03-11T12:00:01Z",
+                artifacts=["C:/ProgramData/XDMModerator/setup_state.json"],
+            ),
+            "tls": StageStatus(
+                status="pending",
+                started_at=None,
+                finished_at=None,
+                artifacts=[],
+            ),
+        },
+        updated_at="2026-03-11T12:00:01Z",
+    )
+
+
+def test_load_setup_state_returns_none_for_missing_file(tmp_path: Path) -> None:
+    from dmguard.setup_state import load_setup_state
+
+    state_path = tmp_path / "setup_state.json"
+
+    assert load_setup_state(state_path) is None
+
+
+def test_save_and_load_setup_state_round_trip(tmp_path: Path) -> None:
+    from dmguard.setup_state import SetupState, load_setup_state, save_setup_state
+
+    state_path = tmp_path / "setup_state.json"
+    expected = make_setup_state()
+
+    save_setup_state(expected, state_path)
+    loaded = load_setup_state(state_path)
+
+    assert loaded == expected
+    assert isinstance(loaded, SetupState)
+
+
+def test_save_setup_state_uses_atomic_replace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dmguard import setup_state
+
+    state_path = tmp_path / "setup_state.json"
+    expected = make_setup_state()
+    captured: dict[str, Path] = {}
+    original_replace = setup_state.os.replace
+
+    def recording_replace(src: str | bytes | Path, dst: str | bytes | Path) -> None:
+        captured["src"] = Path(src)
+        captured["dst"] = Path(dst)
+        original_replace(src, dst)
+
+    monkeypatch.setattr(setup_state.os, "replace", recording_replace)
+
+    setup_state.save_setup_state(expected, state_path)
+
+    assert captured["dst"] == state_path
+    assert captured["src"] != state_path
+    assert captured["src"].parent == state_path.parent
+    assert captured["src"].name.startswith(f".{state_path.name}.")
+    assert captured["src"].suffix == ".tmp"
+    assert not captured["src"].exists()
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["setup_state.json"]


### PR DESCRIPTION
## Summary
- add setup state models and JSON persistence helpers
- add tests for missing-file handling, round-trip loading, and atomic replace
- mark issue #36 complete in issues_todo.md

Closes #36