### PR TITLE
feat(x-client): add authenticated X HTTP client

### DIFF
--- a/dmguard/x_client.py
+++ b/dmguard/x_client.py
@@ -1,0 +1,68 @@
+import httpx
+
+from dmguard.secrets import SecretStore
+
+
+class RateLimitedError(Exception):
+    def __init__(self, retry_after_seconds: int) -> None:
+        super().__init__(f"X API rate limited for {retry_after_seconds} seconds")
+        self.retry_after_seconds = retry_after_seconds
+
+
+class XApiError(Exception):
+    def __init__(self, status_code: int, body: str) -> None:
+        super().__init__(f"X API returned {status_code}")
+        self.status_code = status_code
+        self.body = body
+
+
+class XClient:
+    def __init__(
+        self,
+        secret_store: SecretStore,
+        *,
+        base_url: str = "https://api.x.com",
+        timeout_seconds: float = 10.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={"Authorization": f"Bearer {secret_store.get('x_access_token')}"},
+            timeout=timeout_seconds,
+            transport=transport,
+        )
+
+    async def __aenter__(self) -> "XClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
+        response = await self._client.request(method, url, **kwargs)
+
+        if response.status_code == 429:
+            raise RateLimitedError(_parse_retry_after(response))
+
+        if response.is_error:
+            raise XApiError(response.status_code, response.text)
+
+        return response
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        return await self.request("GET", url, **kwargs)
+
+
+def _parse_retry_after(response: httpx.Response) -> int:
+    retry_after = response.headers.get("Retry-After", "0")
+
+    try:
+        return int(retry_after)
+    except ValueError:
+        return 0
+
+
+__all__ = ["RateLimitedError", "XApiError", "XClient"]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -47,7 +47,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 ## Milestone 6 — X API Client
 
 - [x] #19 Secrets loader interface — deps: #1
-- [ ] #20 X HTTP client — deps: #19
+- [x] #20 X HTTP client — deps: #19
 - [ ] #21 DM lookup client + DTOs — deps: #20
 
 ## Milestone 7 — Media Pipeline

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -1,0 +1,93 @@
+import asyncio
+
+import httpx
+import pytest
+
+
+class StubSecretStore:
+    def __init__(self, access_token: str) -> None:
+        self._access_token = access_token
+
+    def get(self, key: str) -> str:
+        if key != "x_access_token":
+            raise AssertionError(f"Unexpected secret key: {key}")
+
+        return self._access_token
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+async def perform_get(transport: httpx.MockTransport) -> str:
+    from dmguard.x_client import XClient
+
+    async with XClient(StubSecretStore("access-token"), transport=transport) as client:
+        response = await client.get("/2/test")
+
+    return response.text
+
+
+def test_x_client_sends_authorization_header() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer access-token"
+        return httpx.Response(200, text="ok")
+
+    response_body = run(perform_get(httpx.MockTransport(handler)))
+
+    assert response_body == "ok"
+
+
+def test_x_client_uses_ten_second_timeout() -> None:
+    from dmguard.x_client import XClient
+
+    client = XClient(StubSecretStore("access-token"))
+
+    try:
+        timeout = client._client.timeout
+
+        assert timeout.connect == 10.0
+        assert timeout.read == 10.0
+        assert timeout.write == 10.0
+        assert timeout.pool == 10.0
+    finally:
+        run(client.aclose())
+
+
+def test_x_client_raises_rate_limited_error_on_429() -> None:
+    from dmguard.x_client import RateLimitedError, XClient
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "17"})
+
+    async def perform_request() -> None:
+        async with XClient(
+            StubSecretStore("access-token"),
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await client.get("/2/test")
+
+    with pytest.raises(RateLimitedError) as exc_info:
+        run(perform_request())
+
+    assert exc_info.value.retry_after_seconds == 17
+
+
+def test_x_client_raises_api_error_on_other_non_success_statuses() -> None:
+    from dmguard.x_client import XApiError, XClient
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text='{"error":"bad"}')
+
+    async def perform_request() -> None:
+        async with XClient(
+            StubSecretStore("access-token"),
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await client.get("/2/test")
+
+    with pytest.raises(XApiError) as exc_info:
+        run(perform_request())
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.body == '{"error":"bad"}'

--- a/todo.md
+++ b/todo.md
@@ -181,7 +181,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] Token expiry metadata stored in SQLite
 - [x] Refresh failure marks system misconfigured
 - [x] Implement secret loader
-- [ ] Implement X API client
+- [x] Implement X API client
 - [ ] Implement DM lookup DTO parsing
 - [ ] Implement proactive refresh
 - [ ] Add tests for request construction and parsing


### PR DESCRIPTION
## Summary
- add XClient as an httpx.AsyncClient wrapper with bearer auth and a shared 10 second timeout
- raise RateLimitedError for 429 responses and XApiError for other non-2xx responses
- add focused unit coverage and mark issue #20 complete in the backlog trackers

## Testing
- uv run pytest tests/test_x_client.py tests/test_secrets.py

Closes #20