### PR TITLE
feat(webhook): add CRC endpoint

### DIFF
--- a/dmguard/app.py
+++ b/dmguard/app.py
@@ -1,8 +1,13 @@
-from fastapi import FastAPI
+import base64
+import hashlib
+import hmac
+
+from fastapi import FastAPI, HTTPException
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from dmguard.config import AppConfig
+from dmguard.secrets import FileSecretStore, SecretStore
 
 
 APP_VERSION = "0.1.0"
@@ -51,10 +56,24 @@ class RequestBodyLimitMiddleware:
         await self.app(scope, buffered_receive, send)
 
 
-def create_app(config: AppConfig) -> FastAPI:
+def build_crc_response_token(crc_token: str, consumer_secret: str) -> str:
+    digest = hmac.digest(
+        consumer_secret.encode("utf-8"),
+        crc_token.encode("utf-8"),
+        hashlib.sha256,
+    )
+    encoded_digest = base64.b64encode(digest).decode("utf-8")
+    return f"sha256={encoded_digest}"
+
+
+def create_app(
+    config: AppConfig,
+    secret_store: SecretStore | None = None,
+) -> FastAPI:
     docs_url = "/docs" if config.debug else None
     redoc_url = "/redoc" if config.debug else None
     openapi_url = "/openapi.json" if config.debug else None
+    app_secret_store = secret_store or FileSecretStore()
 
     app = FastAPI(
         docs_url=docs_url,
@@ -67,6 +86,15 @@ def create_app(config: AppConfig) -> FastAPI:
         max_body_bytes=MAX_REQUEST_BODY_BYTES,
     )
 
+    @app.get("/webhooks/x")
+    async def crc(crc_token: str | None = None) -> dict[str, str]:
+        if crc_token is None:
+            raise HTTPException(status_code=400, detail="Missing crc_token")
+
+        consumer_secret = app_secret_store.get("x_consumer_secret")
+        response_token = build_crc_response_token(crc_token, consumer_secret)
+        return {"response_token": response_token}
+
     @app.get("/health")
     async def health() -> dict[str, bool]:
         return {"ok": True}
@@ -78,4 +106,9 @@ def create_app(config: AppConfig) -> FastAPI:
     return app
 
 
-__all__ = ["APP_VERSION", "MAX_REQUEST_BODY_BYTES", "create_app"]
+__all__ = [
+    "APP_VERSION",
+    "MAX_REQUEST_BODY_BYTES",
+    "build_crc_response_token",
+    "create_app",
+]

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -39,7 +39,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 5 — Webhook Receiver
 
-- [ ] #15 CRC endpoint — deps: #4, #2
+- [x] #15 CRC endpoint — deps: #4, #2
 - [ ] #16 Signature verification — deps: #4
 - [ ] #17 Webhook POST + idempotent enqueue — deps: #7, #16
 - [ ] #18 Rejected request persistence — deps: #7, #16

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,7 @@
+import base64
+import hashlib
+import hmac
+
 from fastapi import Request
 from fastapi.testclient import TestClient
 
@@ -12,6 +16,17 @@ def build_config(*, debug: bool = False) -> AppConfig:
         public_hostname="dmguard.duckdns.org",
         acme_email="ori@example.com",
     )
+
+
+class StubSecretStore:
+    def __init__(self, consumer_secret: str) -> None:
+        self._consumer_secret = consumer_secret
+
+    def get(self, key: str) -> str:
+        if key != "x_consumer_secret":
+            raise AssertionError(f"Unexpected secret key: {key}")
+
+        return self._consumer_secret
 
 
 def test_create_app_succeeds_without_db() -> None:
@@ -42,6 +57,36 @@ def test_version_endpoint_returns_stub_version() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"version": APP_VERSION}
+
+
+def test_crc_endpoint_returns_expected_response_token() -> None:
+    from dmguard.app import create_app
+
+    crc_token = "challenge-token"
+    consumer_secret = "consumer-secret"
+    client = TestClient(create_app(build_config(), StubSecretStore(consumer_secret)))
+
+    response = client.get("/webhooks/x", params={"crc_token": crc_token})
+
+    expected_digest = hmac.digest(
+        consumer_secret.encode("utf-8"),
+        crc_token.encode("utf-8"),
+        hashlib.sha256,
+    )
+    expected_token = base64.b64encode(expected_digest).decode("utf-8")
+
+    assert response.status_code == 200
+    assert response.json() == {"response_token": f"sha256={expected_token}"}
+
+
+def test_crc_endpoint_returns_400_when_crc_token_is_missing() -> None:
+    from dmguard.app import create_app
+
+    client = TestClient(create_app(build_config(), StubSecretStore("consumer-secret")))
+
+    response = client.get("/webhooks/x")
+
+    assert response.status_code == 400
 
 
 def test_non_debug_app_hides_docs_and_openapi() -> None:

--- a/todo.md
+++ b/todo.md
@@ -87,7 +87,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 
 ## 5. Runtime API surface
 
-- [ ] Implement `GET /webhooks/x` for CRC
+- [x] Implement `GET /webhooks/x` for CRC
 - [ ] Implement `POST /webhooks/x` for webhook deliveries
 - [ ] Implement `GET /health`
 - [ ] Implement `GET /version`


### PR DESCRIPTION
## Summary
- add GET /webhooks/x CRC handling using the existing secret-store abstraction
- add app tests for CRC token generation and missing crc_token handling
- mark issue tracking for #15 complete in todo.md and issues_todo.md

## Testing
- uv run pytest tests/test_app.py
- uv run pytest tests/test_config.py tests/test_secrets.py

Closes #15