### PR TITLE
fix(classifier): wrap ValidationError from bad subprocess output in ClassifierError

### DIFF
--- a/dmguard/classifier_runner.py
+++ b/dmguard/classifier_runner.py
@@ -65,7 +65,12 @@ def run_classifier(
         if process.returncode != 0:
             raise ClassifierError(stderr_text.strip() or "Classifier process failed")
 
-        return ClassifierResponse.model_validate_json(stdout_text)
+        try:
+            return ClassifierResponse.model_validate_json(stdout_text)
+        except Exception as exc:
+            raise ClassifierError(
+                f"Classifier returned invalid response: {exc}"
+            ) from exc
     finally:
         if process is not None and process.poll() is None:
             process.kill()

--- a/tests/test_classifier_runner.py
+++ b/tests/test_classifier_runner.py
@@ -201,3 +201,40 @@ def test_run_classifier_kills_timed_out_process_and_cleans_up_input_file(
     assert elapsed < 2
     assert not input_path.exists()
     assert not completed_path.exists()
+
+
+def test_run_classifier_raises_classifier_error_on_invalid_json_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dmguard import classifier_runner
+
+    tmp_dir = tmp_path / "runner-tmp"
+    marker_path = tmp_path / "input-path.txt"
+    script_path = write_script(
+        tmp_path,
+        "classifier_bad_output.py",
+        """
+        from pathlib import Path
+        import sys
+
+        marker_path = Path(sys.argv[1])
+        input_path = Path(sys.argv[2])
+        marker_path.write_text(str(input_path), encoding="utf-8")
+        print("this is not valid json")
+        """,
+    )
+
+    monkeypatch.setattr(classifier_runner, "TMP_DIR", tmp_dir)
+
+    with pytest.raises(classifier_runner.ClassifierError):
+        classifier_runner.run_classifier(
+            {
+                "mode": "image",
+                "files": ["frame-1.jpg"],
+                "policy": "violence_gore",
+            },
+            [sys.executable, str(script_path), str(marker_path)],
+        )
+
+    input_path = read_input_path(marker_path)
+    assert not input_path.exists()


### PR DESCRIPTION
## Summary

- `run_classifier` called `ClassifierResponse.model_validate_json()` bare, so a zero-exit classifier that produces malformed JSON raised `pydantic_core.ValidationError` instead of `ClassifierError`, breaking the module's exception contract
- Wrapped the call in `try/except Exception` → re-raise as `ClassifierError`
- Added a test covering the malformed-output path and verifying temp-file cleanup

Identified during code review of #70.

Closes #72

## Test plan

- [ ] `uv run pytest tests/test_classifier_runner.py -v` — all 4 tests pass, including the new `test_run_classifier_raises_classifier_error_on_invalid_json_output`
- [ ] `uv run ruff check dmguard/classifier_runner.py tests/test_classifier_runner.py`