### PR TITLE
feat(setup): add setup subcommands

### DIFF
--- a/dmguard/cli.py
+++ b/dmguard/cli.py
@@ -1,0 +1,401 @@
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+import getpass
+import json
+import shutil
+import socket
+import sys
+
+import httpx
+import yaml
+
+from dmguard.classifier_runner import run_classifier
+from dmguard.paths import CONFIG_PATH, PROGRAM_DATA_DIR, SECRETS_PATH
+from dmguard.setup_logger import SetupLogger
+from dmguard.setup_state import (
+    SETUP_STAGE_ORDER,
+    SetupState,
+    StageStatus,
+    describe_verbose_stage_changes,
+    invalidate_changed_stages,
+    load_setup_state,
+    save_setup_state,
+)
+
+
+SETUP_STATE_PATH = PROGRAM_DATA_DIR / "setup_state.json"
+SETUP_LOG_PATH = PROGRAM_DATA_DIR / "setup.log"
+DUCKDNS_ARTIFACT_PATH = PROGRAM_DATA_DIR / "duckdns.txt"
+TRAEFIK_DIR = PROGRAM_DATA_DIR / "traefik"
+KNOWN_SETUP_OUTPUTS = (
+    CONFIG_PATH,
+    SECRETS_PATH,
+    SETUP_STATE_PATH,
+    SETUP_LOG_PATH,
+    DUCKDNS_ARTIFACT_PATH,
+    TRAEFIK_DIR,
+)
+DEFAULT_WARMUP_CLASSIFIER_CMD = (
+    sys.executable,
+    "-m",
+    "dmguard.classifier_fake",
+    "--force-safe",
+)
+SETUP_CONFIG_DEFAULTS = {
+    "debug": False,
+    "log_level": "INFO",
+    "port": 8080,
+    "host": "127.0.0.1",
+    "debug_dashboard_port": 8081,
+}
+TEXT_PROMPTS = {
+    "public_hostname": "Public DuckDNS hostname",
+    "acme_email": "ACME email",
+}
+SECRET_PROMPTS = {
+    "duckdns_token": "DuckDNS token",
+    "x_access_token": "X access token",
+    "x_refresh_token": "X refresh token",
+    "x_consumer_secret": "X consumer secret",
+    "x_app_bearer": "X app bearer",
+    "hf_token": "Hugging Face token",
+}
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser(prog="dmguard")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    setup_parser = subparsers.add_parser("setup")
+    setup_parser.add_argument("--debug", action="store_true")
+    setup_parser.add_argument("--log-level", default=SETUP_CONFIG_DEFAULTS["log_level"])
+    setup_parser.add_argument("--port", type=int, default=SETUP_CONFIG_DEFAULTS["port"])
+    setup_parser.add_argument("--host", default=SETUP_CONFIG_DEFAULTS["host"])
+    setup_parser.add_argument(
+        "--debug-dashboard-port",
+        type=int,
+        default=SETUP_CONFIG_DEFAULTS["debug_dashboard_port"],
+    )
+    setup_parser.add_argument("--public-hostname")
+    setup_parser.add_argument("--acme-email")
+    setup_parser.add_argument("--duckdns-token")
+    setup_parser.add_argument("--x-access-token")
+    setup_parser.add_argument("--x-refresh-token")
+    setup_parser.add_argument("--x-consumer-secret")
+    setup_parser.add_argument("--x-app-bearer")
+    setup_parser.add_argument("--hf-token")
+    setup_parser.add_argument("--verbose", action="store_true")
+
+    reset_parser = subparsers.add_parser("reset")
+    reset_parser.add_argument("--force", action="store_true")
+
+    subparsers.add_parser("warmup")
+
+    status_parser = subparsers.add_parser("status")
+    status_parser.add_argument("--full", action="store_true")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code)
+
+    try:
+        if args.command == "setup":
+            return handle_setup(args)
+        if args.command == "reset":
+            return handle_reset(args)
+        if args.command == "warmup":
+            return handle_warmup()
+        if args.command == "status":
+            return handle_status(args)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Unknown command: {args.command}", file=sys.stderr)
+    return 2
+
+
+def handle_setup(args) -> int:
+    logger = SetupLogger(SETUP_LOG_PATH)
+    effective_args = {
+        "debug": args.debug,
+        "log_level": args.log_level,
+        "port": args.port,
+        "host": args.host,
+        "debug_dashboard_port": args.debug_dashboard_port,
+        "public_hostname": _get_text_value(args.public_hostname, "public_hostname"),
+        "acme_email": _get_text_value(args.acme_email, "acme_email"),
+    }
+    secret_values = {
+        "duckdns_token": _get_secret_value(args.duckdns_token, "duckdns_token"),
+        "x_access_token": _get_secret_value(args.x_access_token, "x_access_token"),
+        "x_refresh_token": _get_secret_value(args.x_refresh_token, "x_refresh_token"),
+        "x_consumer_secret": _get_secret_value(
+            args.x_consumer_secret, "x_consumer_secret"
+        ),
+        "x_app_bearer": _get_secret_value(args.x_app_bearer, "x_app_bearer"),
+        "hf_token": _get_secret_value(args.hf_token, "hf_token"),
+    }
+    state = _load_or_create_setup_state()
+    invalidated_stages: list[str] = []
+    verbose_messages: list[str] = []
+
+    logger.log("setup started")
+
+    if state.effective_args:
+        if args.verbose:
+            verbose_messages = describe_verbose_stage_changes(state, effective_args)
+        invalidated_stages = invalidate_changed_stages(state, effective_args)
+        if args.verbose:
+            for message in verbose_messages:
+                print(message)
+    else:
+        state.effective_args = dict(effective_args)
+
+    _write_yaml(CONFIG_PATH, effective_args)
+    _write_json(SECRETS_PATH, secret_values)
+
+    timestamp = _utc_now()
+    state.last_command = "setup --verbose" if args.verbose else "setup"
+    state.updated_at = timestamp
+    _mark_stage_done(
+        state,
+        "preflight",
+        timestamp=timestamp,
+        artifacts=[str(SETUP_STATE_PATH)],
+    )
+    _mark_stage_done(
+        state,
+        "local_config",
+        timestamp=timestamp,
+        artifacts=[str(CONFIG_PATH)],
+    )
+    _mark_stage_done(
+        state,
+        "x_auth",
+        timestamp=timestamp,
+        artifacts=[str(SECRETS_PATH)],
+    )
+    save_setup_state(state, SETUP_STATE_PATH)
+
+    logger.log(f"setup saved config_path={CONFIG_PATH}")
+    logger.log(f"setup saved secrets_path={SECRETS_PATH}")
+
+    if args.verbose and invalidated_stages:
+        print(json.dumps({"invalidated_stages": invalidated_stages}, indent=2))
+
+    return 0
+
+
+def handle_reset(args) -> int:
+    if not args.force:
+        print("reset requires --force", file=sys.stderr)
+        return 2
+
+    for path in KNOWN_SETUP_OUTPUTS:
+        _delete_path(path)
+
+    return 0
+
+
+def handle_warmup() -> int:
+    payload = run_setup_warmup()
+    state = load_setup_state(SETUP_STATE_PATH)
+
+    if state is not None:
+        timestamp = _utc_now()
+        state.last_command = "warmup"
+        state.updated_at = timestamp
+        _mark_stage_done(state, "warmup", timestamp=timestamp)
+        save_setup_state(state, SETUP_STATE_PATH)
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def handle_status(args) -> int:
+    state = load_setup_state(SETUP_STATE_PATH)
+    payload = {
+        "state_path": str(SETUP_STATE_PATH),
+        "configured": state is not None,
+        "last_command": state.last_command if state is not None else None,
+        "updated_at": state.updated_at if state is not None else None,
+        "effective_args": state.effective_args if state is not None else None,
+        "stages": _dump_stages(state),
+        "remote_checks": None,
+    }
+
+    if args.full:
+        payload["remote_checks"] = build_remote_checks(state)
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def run_setup_warmup() -> dict[str, object]:
+    response = run_classifier(
+        {
+            "mode": "image",
+            "files": ["warmup.jpg"],
+            "policy": "violence_gore",
+        },
+        DEFAULT_WARMUP_CLASSIFIER_CMD,
+    )
+    return response.model_dump(mode="json")
+
+
+def build_remote_checks(state: SetupState | None) -> dict[str, object]:
+    if state is None:
+        return {
+            "duckdns_resolution": {"ok": False, "error": "setup state missing"},
+            "public_https": {"ok": False, "error": "setup state missing"},
+        }
+
+    hostname = state.effective_args.get("public_hostname")
+    if not isinstance(hostname, str) or not hostname:
+        return {
+            "duckdns_resolution": {"ok": False, "error": "public_hostname missing"},
+            "public_https": {"ok": False, "error": "public_hostname missing"},
+        }
+
+    return {
+        "duckdns_resolution": check_duckdns_resolution(hostname),
+        "public_https": check_public_https_reachability(hostname),
+    }
+
+
+def check_duckdns_resolution(hostname: str) -> dict[str, object]:
+    try:
+        address_info = socket.getaddrinfo(hostname, 443, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        return {"ok": False, "hostname": hostname, "error": str(exc)}
+
+    addresses = sorted({item[4][0] for item in address_info})
+    return {"ok": True, "hostname": hostname, "addresses": addresses}
+
+
+def check_public_https_reachability(hostname: str) -> dict[str, object]:
+    url = f"https://{hostname}/webhooks/x"
+
+    try:
+        response = httpx.get(url, timeout=5.0, follow_redirects=False)
+    except httpx.HTTPError as exc:
+        return {"ok": False, "hostname": hostname, "error": str(exc)}
+
+    return {
+        "ok": True,
+        "hostname": hostname,
+        "status_code": response.status_code,
+        "url": str(response.request.url),
+    }
+
+
+def _load_or_create_setup_state() -> SetupState:
+    state = load_setup_state(SETUP_STATE_PATH)
+    if state is not None:
+        return state
+
+    return SetupState(
+        last_command="setup",
+        effective_args={},
+        stages={
+            stage_name: StageStatus(
+                status="pending",
+                started_at=None,
+                finished_at=None,
+                artifacts=[],
+            )
+            for stage_name in SETUP_STAGE_ORDER
+        },
+        updated_at=_utc_now(),
+    )
+
+
+def _mark_stage_done(
+    state: SetupState,
+    stage_name: str,
+    *,
+    timestamp: str,
+    artifacts: list[str] | None = None,
+) -> None:
+    state.stages[stage_name] = StageStatus(
+        status="done",
+        started_at=timestamp,
+        finished_at=timestamp,
+        artifacts=artifacts or [],
+    )
+
+
+def _get_text_value(current_value: str | None, prompt_key: str) -> str:
+    if current_value:
+        return current_value
+
+    prompt = f"{TEXT_PROMPTS[prompt_key]}: "
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError(f"{prompt_key} is required")
+    return value
+
+
+def _get_secret_value(current_value: str | None, prompt_key: str) -> str:
+    if current_value:
+        return current_value
+
+    prompt = f"{SECRET_PROMPTS[prompt_key]}: "
+    value = getpass.getpass(prompt).strip()
+    if not value:
+        raise ValueError(f"{prompt_key} is required")
+    return value
+
+
+def _dump_stages(state: SetupState | None) -> dict[str, object] | None:
+    if state is None:
+        return None
+
+    return {name: stage.model_dump(mode="json") for name, stage in state.stages.items()}
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _delete_path(path: Path) -> None:
+    if not path.exists():
+        return
+
+    if path.is_dir():
+        shutil.rmtree(path)
+        return
+
+    path.unlink()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+__all__ = [
+    "KNOWN_SETUP_OUTPUTS",
+    "SETUP_LOG_PATH",
+    "SETUP_STATE_PATH",
+    "build_parser",
+    "check_duckdns_resolution",
+    "check_public_https_reachability",
+    "main",
+    "run_setup_warmup",
+]

--- a/dmguard/secrets.py
+++ b/dmguard/secrets.py
@@ -7,6 +7,7 @@ from dmguard.paths import SECRETS_PATH
 
 SECRET_KEYS = frozenset(
     {
+        "duckdns_token",
         "x_access_token",
         "x_refresh_token",
         "x_consumer_secret",

--- a/dmguard/setup_state.py
+++ b/dmguard/setup_state.py
@@ -22,7 +22,7 @@ class SetupState(BaseModel):
     updated_at: str
 
 
-_SETUP_STAGE_ORDER = (
+SETUP_STAGE_ORDER = (
     "preflight",
     "local_config",
     "x_auth",
@@ -34,9 +34,7 @@ _SETUP_STAGE_ORDER = (
     "warmup",
     "app_service",
 )
-_STAGE_INDEX = {
-    stage_name: index for index, stage_name in enumerate(_SETUP_STAGE_ORDER)
-}
+_STAGE_INDEX = {stage_name: index for index, stage_name in enumerate(SETUP_STAGE_ORDER)}
 _ARG_EARLIEST_STAGE = {
     "debug": "preflight",
     "log_level": "local_config",
@@ -147,13 +145,13 @@ def _invalidated_stage_names(
     return [
         stage_name
         for stage_name in _ordered_stage_names(stages)
-        if _STAGE_INDEX.get(stage_name, len(_SETUP_STAGE_ORDER)) >= earliest_index
+        if _STAGE_INDEX.get(stage_name, len(SETUP_STAGE_ORDER)) >= earliest_index
     ]
 
 
 def _ordered_stage_names(stages: dict[str, StageStatus]) -> list[str]:
     ordered_stage_names = [
-        stage_name for stage_name in _SETUP_STAGE_ORDER if stage_name in stages
+        stage_name for stage_name in SETUP_STAGE_ORDER if stage_name in stages
     ]
     ordered_stage_names.extend(
         stage_name for stage_name in stages if stage_name not in _STAGE_INDEX
@@ -162,6 +160,7 @@ def _ordered_stage_names(stages: dict[str, StageStatus]) -> list[str]:
 
 
 __all__ = [
+    "SETUP_STAGE_ORDER",
     "SetupState",
     "StageStatus",
     "compute_args_hash",

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -87,7 +87,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 ## Milestone 13 — Setup Stages + Admin CLI
 
-- [ ] #39 Setup subcommands — deps: #36, #37, #38
+- [x] #39 Setup subcommands — deps: #36, #37, #38
 - [ ] #40 Admin CLI — deps: #7, #27, #30
 
 ## Milestone 14 — End-to-End

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "uvicorn>=0.41.0",
 ]
 
+[project.scripts]
+dmguard = "dmguard.cli:main"
+
 [dependency-groups]
 dev = [
     "prek>=0.3.5",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,329 @@
+from pathlib import Path
+import json
+
+import pytest
+import yaml
+
+
+def configure_cli_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    from dmguard import cli
+
+    data_root = tmp_path / "program-data"
+
+    monkeypatch.setattr(cli, "PROGRAM_DATA_DIR", data_root)
+    monkeypatch.setattr(cli, "CONFIG_PATH", data_root / "config.yaml")
+    monkeypatch.setattr(cli, "SECRETS_PATH", data_root / "secrets.bin")
+    monkeypatch.setattr(cli, "SETUP_STATE_PATH", data_root / "setup_state.json")
+    monkeypatch.setattr(cli, "SETUP_LOG_PATH", data_root / "setup.log")
+    monkeypatch.setattr(
+        cli,
+        "KNOWN_SETUP_OUTPUTS",
+        (
+            cli.CONFIG_PATH,
+            cli.SECRETS_PATH,
+            cli.SETUP_STATE_PATH,
+            cli.SETUP_LOG_PATH,
+            data_root / "duckdns.txt",
+            data_root / "traefik",
+        ),
+    )
+
+    return cli
+
+
+def save_state(state_path: Path) -> None:
+    from dmguard.setup_state import SetupState, StageStatus, save_setup_state
+
+    save_setup_state(
+        SetupState(
+            last_command="setup --verbose",
+            effective_args={
+                "debug": False,
+                "log_level": "INFO",
+                "port": 8080,
+                "host": "127.0.0.1",
+                "debug_dashboard_port": 8081,
+                "public_hostname": "dmguard.duckdns.org",
+                "acme_email": "ops@example.com",
+            },
+            stages={
+                "preflight": StageStatus(
+                    status="done",
+                    started_at="2026-03-11T12:00:00+00:00",
+                    finished_at="2026-03-11T12:00:00+00:00",
+                    artifacts=[str(state_path)],
+                ),
+                "local_config": StageStatus(
+                    status="done",
+                    started_at="2026-03-11T12:00:00+00:00",
+                    finished_at="2026-03-11T12:00:00+00:00",
+                    artifacts=[str(state_path.parent / "config.yaml")],
+                ),
+                "x_auth": StageStatus(
+                    status="done",
+                    started_at="2026-03-11T12:00:00+00:00",
+                    finished_at="2026-03-11T12:00:00+00:00",
+                    artifacts=[str(state_path.parent / "secrets.bin")],
+                ),
+                "duckdns": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "traefik": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "tls": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "public_reachability": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "x_webhook": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "warmup": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+                "app_service": StageStatus(
+                    status="pending",
+                    started_at=None,
+                    finished_at=None,
+                    artifacts=[],
+                ),
+            },
+            updated_at="2026-03-11T12:00:00+00:00",
+        ),
+        state_path,
+    )
+
+
+def test_build_parser_recognizes_setup_subcommands() -> None:
+    from dmguard.cli import build_parser
+
+    parser = build_parser()
+
+    assert parser.parse_args(["setup"]).command == "setup"
+    assert parser.parse_args(["reset", "--force"]).command == "reset"
+    assert parser.parse_args(["warmup"]).command == "warmup"
+    assert parser.parse_args(["status"]).command == "status"
+    assert parser.parse_args(["status", "--full"]).full is True
+
+
+def test_setup_collects_expected_inputs_and_persists_outputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    text_prompts = iter(["dmguard.duckdns.org", "ops@example.com"])
+    secret_prompts = iter(
+        [
+            "duckdns-token",
+            "access-token",
+            "refresh-token",
+            "consumer-secret",
+            "app-bearer",
+            "hf-token",
+        ]
+    )
+
+    monkeypatch.setattr("builtins.input", lambda _: next(text_prompts))
+    monkeypatch.setattr(cli.getpass, "getpass", lambda _: next(secret_prompts))
+
+    exit_code = cli.main(["setup"])
+
+    saved_state = json.loads(cli.SETUP_STATE_PATH.read_text(encoding="utf-8"))
+    saved_config = yaml.safe_load(cli.CONFIG_PATH.read_text(encoding="utf-8"))
+    saved_secrets = json.loads(cli.SECRETS_PATH.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert saved_state["last_command"] == "setup"
+    assert saved_state["effective_args"]["public_hostname"] == "dmguard.duckdns.org"
+    assert saved_state["effective_args"]["acme_email"] == "ops@example.com"
+    assert saved_state["stages"]["local_config"]["status"] == "done"
+    assert saved_state["stages"]["x_auth"]["status"] == "done"
+    assert saved_config == {
+        "debug": False,
+        "log_level": "INFO",
+        "port": 8080,
+        "host": "127.0.0.1",
+        "debug_dashboard_port": 8081,
+        "public_hostname": "dmguard.duckdns.org",
+        "acme_email": "ops@example.com",
+    }
+    assert saved_secrets == {
+        "duckdns_token": "duckdns-token",
+        "x_access_token": "access-token",
+        "x_refresh_token": "refresh-token",
+        "x_consumer_secret": "consumer-secret",
+        "x_app_bearer": "app-bearer",
+        "hf_token": "hf-token",
+    }
+
+
+def test_setup_uses_flags_without_prompting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+
+    def fail_prompt(_: str) -> str:
+        raise AssertionError("unexpected prompt")
+
+    monkeypatch.setattr("builtins.input", fail_prompt)
+    monkeypatch.setattr(cli.getpass, "getpass", fail_prompt)
+
+    exit_code = cli.main(
+        [
+            "setup",
+            "--public-hostname",
+            "dmguard.duckdns.org",
+            "--acme-email",
+            "ops@example.com",
+            "--duckdns-token",
+            "duckdns-token",
+            "--x-access-token",
+            "access-token",
+            "--x-refresh-token",
+            "refresh-token",
+            "--x-consumer-secret",
+            "consumer-secret",
+            "--x-app-bearer",
+            "app-bearer",
+            "--hf-token",
+            "hf-token",
+        ]
+    )
+
+    saved_secrets = json.loads(cli.SECRETS_PATH.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert saved_secrets["duckdns_token"] == "duckdns-token"
+
+
+def test_reset_without_force_fails_safely(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    cli.SETUP_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    cli.SETUP_STATE_PATH.write_text("{}", encoding="utf-8")
+
+    exit_code = cli.main(["reset"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "--force" in captured.err
+    assert cli.SETUP_STATE_PATH.exists()
+
+
+def test_reset_force_deletes_known_setup_outputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    for path in cli.KNOWN_SETUP_OUTPUTS:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.suffix:
+            path.write_text("generated", encoding="utf-8")
+        else:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / "artifact.txt").write_text("generated", encoding="utf-8")
+
+    exit_code = cli.main(["reset", "--force"])
+
+    assert exit_code == 0
+    assert all(not path.exists() for path in cli.KNOWN_SETUP_OUTPUTS)
+
+
+def test_status_prints_local_status_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    cli.SETUP_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    save_state(cli.SETUP_STATE_PATH)
+
+    exit_code = cli.main(["status"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["configured"] is True
+    assert payload["last_command"] == "setup --verbose"
+    assert payload["remote_checks"] is None
+    assert payload["stages"]["local_config"]["status"] == "done"
+
+
+def test_status_full_adds_remote_checks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    cli.SETUP_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    save_state(cli.SETUP_STATE_PATH)
+    monkeypatch.setattr(
+        cli,
+        "check_duckdns_resolution",
+        lambda hostname: {"ok": True, "hostname": hostname, "addresses": ["1.2.3.4"]},
+    )
+    monkeypatch.setattr(
+        cli,
+        "check_public_https_reachability",
+        lambda hostname: {"ok": False, "hostname": hostname, "error": "timeout"},
+    )
+
+    exit_code = cli.main(["status", "--full"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["remote_checks"] == {
+        "duckdns_resolution": {
+            "ok": True,
+            "hostname": "dmguard.duckdns.org",
+            "addresses": ["1.2.3.4"],
+        },
+        "public_https": {
+            "ok": False,
+            "hostname": "dmguard.duckdns.org",
+            "error": "timeout",
+        },
+    }
+
+
+def test_warmup_invokes_setup_warmup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    cli = configure_cli_paths(monkeypatch, tmp_path)
+    calls: list[str] = []
+
+    def fake_run_setup_warmup() -> dict[str, object]:
+        calls.append("warmup")
+        return {"policy": "violence_gore", "yes_prob": 0.01}
+
+    monkeypatch.setattr(cli, "run_setup_warmup", fake_run_setup_warmup)
+
+    exit_code = cli.main(["warmup"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert calls == ["warmup"]
+    assert json.loads(captured.out) == {
+        "policy": "violence_gore",
+        "yes_prob": 0.01,
+    }

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -16,6 +16,7 @@ def test_file_secret_store_get_returns_expected_value(tmp_path: Path) -> None:
         tmp_path,
         """
 {
+  "duckdns_token": "duckdns-token",
   "x_access_token": "access-token",
   "x_refresh_token": "refresh-token",
   "x_consumer_secret": "consumer-secret",
@@ -27,6 +28,7 @@ def test_file_secret_store_get_returns_expected_value(tmp_path: Path) -> None:
 
     store = FileSecretStore(secrets_path)
 
+    assert store.get("duckdns_token") == "duckdns-token"
     assert store.get("x_access_token") == "access-token"
     assert store.get("hf_token") == "hf-token"
 
@@ -40,6 +42,7 @@ def test_file_secret_store_raises_missing_secret_error_for_unknown_key(
         tmp_path,
         """
 {
+  "duckdns_token": "duckdns-token",
   "x_access_token": "access-token",
   "x_refresh_token": "refresh-token",
   "x_consumer_secret": "consumer-secret",
@@ -80,6 +83,7 @@ def test_file_secret_store_uses_default_secrets_path(
         tmp_path,
         """
 {
+  "duckdns_token": "duckdns-token",
   "x_access_token": "access-token",
   "x_refresh_token": "refresh-token",
   "x_consumer_secret": "consumer-secret",

--- a/todo.md
+++ b/todo.md
@@ -326,6 +326,8 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] `config.yaml` is installer-authored, runtime-read, non-secret config
 - [x] Public HTTPS reachability is checked before webhook registration
 - [x] Unsupported environment => setup fails
+- [x] Implement setup subcommands (`setup`, `reset --force`, `warmup`, `status`, `status --full`)
+- [x] Add setup CLI tests
 - [ ] Implement preflight stage
 - [ ] Implement local config stage
 - [ ] Implement X auth stage


### PR DESCRIPTION
## Summary
- add the dmguard setup CLI with setup, reset --force, warmup, and status --full
- persist installer-authored config and secrets, plus JSON status output and remote reachability checks
- add setup CLI coverage, extend secrets for duckdns_token, and update backlog tracking for completed issue-39 work

## Testing
- uv run pytest tests/test_cli.py tests/test_secrets.py tests/test_setup_state.py tests/test_setup_logger.py tests/test_classifier_runner.py tests/test_classifier_fake.py
- uv run ruff check dmguard/cli.py dmguard/secrets.py dmguard/setup_state.py tests/test_cli.py tests/test_secrets.py

Closes #39