### PR TITLE
feat(scheduler): implement dequeue and claim transaction

### DIFF
--- a/dmguard/scheduler.py
+++ b/dmguard/scheduler.py
@@ -1,9 +1,14 @@
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 
 import aiosqlite
 
-from dmguard.job_machine import JobStatus, next_backoff_seconds
-from dmguard.repo_jobs import list_stale_processing_jobs, update_job_status
+from dmguard.job_machine import JobStage, JobStatus, is_terminal, next_backoff_seconds
+from dmguard.repo_jobs import (
+    list_runnable_jobs,
+    list_stale_processing_jobs,
+    update_job_status,
+)
 
 
 def _utc_now() -> str:
@@ -22,6 +27,76 @@ def _format_utc(timestamp: datetime) -> str:
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z")
     )
+
+
+async def dequeue_next_job(
+    connection: aiosqlite.Connection,
+) -> dict[str, object] | None:
+    jobs = await list_runnable_jobs(connection, now=_utc_now())
+    return jobs[0] if jobs else None
+
+
+async def claim_job(
+    connection: aiosqlite.Connection,
+    job_id: int,
+) -> bool:
+    now = _utc_now()
+    cursor = await connection.execute(
+        """
+        UPDATE jobs
+        SET
+          status = ?,
+          attempt = attempt + 1,
+          processing_started_at = ?,
+          updated_at = ?
+        WHERE job_id = ? AND status = ?
+        """,
+        (
+            JobStatus.processing.value,
+            now,
+            now,
+            job_id,
+            JobStatus.queued.value,
+        ),
+    )
+
+    await cursor.close()
+    return cursor.rowcount == 1
+
+
+async def advance_stage(
+    connection: aiosqlite.Connection,
+    job_id: int,
+    new_stage: JobStage | str,
+) -> bool:
+    stage_value = new_stage.value if isinstance(new_stage, Enum) else new_stage
+    cursor = await connection.execute(
+        """
+        UPDATE jobs
+        SET
+          stage = ?,
+          attempt = 0,
+          updated_at = ?
+        WHERE job_id = ?
+        """,
+        (stage_value, _utc_now(), job_id),
+    )
+
+    await cursor.close()
+    return cursor.rowcount == 1
+
+
+async def complete_job(
+    connection: aiosqlite.Connection,
+    job_id: int,
+    status: JobStatus | str,
+) -> bool:
+    if isinstance(status, str):
+        status = JobStatus(status)
+    if not is_terminal(status):
+        raise ValueError("complete_job requires a terminal status")
+
+    return await update_job_status(connection, job_id, status=status)
 
 
 async def schedule_retry(
@@ -91,6 +166,10 @@ async def reset_stale_jobs(
 
 
 __all__ = [
+    "advance_stage",
+    "claim_job",
+    "complete_job",
+    "dequeue_next_job",
     "reset_stale_jobs",
     "schedule_429_retry",
     "schedule_retry",

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -27,7 +27,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 ## Milestone 3 — Job State Machine
 
 - [x] #8 Status/stage enums + transition logic (pure) — deps: _none_
-- [ ] #9 Dequeue + claim transaction — deps: #7, #8
+- [x] #9 Dequeue + claim transaction — deps: #7, #8
 - [x] #10 Retry scheduling — deps: #7, #8
 
 ## Milestone 4 — FastAPI Lifecycle

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -6,12 +7,255 @@ from tests.conftest import bootstrap_database, insert_event_row, insert_job_row,
 from dmguard.job_machine import JobStage, JobStatus
 
 
+def utc_iso(dt: datetime) -> str:
+    return (
+        dt.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
 async def fetch_job(db_path: Path, job_id: int) -> dict[str, object] | None:
     from dmguard.db import get_connection
     from dmguard.repo_jobs import get_job
 
     async with get_connection(db_path) as connection:
         return await get_job(connection, job_id)
+
+
+def test_dequeue_next_job_returns_oldest_runnable_job(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1"))
+    run(insert_event_row(db_path, event_id="event-2"))
+    run(insert_event_row(db_path, event_id="event-3"))
+    run(insert_event_row(db_path, event_id="event-4"))
+
+    oldest_job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at=utc_iso(now - timedelta(minutes=2)),
+        )
+    )
+    run(
+        insert_job_row(
+            db_path,
+            event_id="event-2",
+            next_run_at=utc_iso(now - timedelta(minutes=1)),
+        )
+    )
+    run(
+        insert_job_row(
+            db_path,
+            event_id="event-3",
+            next_run_at=utc_iso(now + timedelta(minutes=1)),
+        )
+    )
+    run(
+        insert_job_row(
+            db_path,
+            event_id="event-4",
+            next_run_at=utc_iso(now - timedelta(minutes=3)),
+            status=JobStatus.processing,
+        )
+    )
+
+    async def scenario() -> dict[str, object] | None:
+        from dmguard.db import get_connection
+        from dmguard.scheduler import dequeue_next_job
+
+        async with get_connection(db_path) as connection:
+            return await dequeue_next_job(connection)
+
+    job = run(scenario())
+
+    assert job is not None
+    assert job["job_id"] == oldest_job_id
+    assert job["event_id"] == "event-1"
+    assert job["status"] == JobStatus.queued.value
+
+
+def test_claim_job_is_idempotent_and_sets_processing_fields(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1"))
+    job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at="2026-03-11T00:00:00Z",
+        )
+    )
+
+    async def scenario() -> tuple[bool, bool, dict[str, object] | None]:
+        from dmguard.db import get_connection
+        from dmguard.repo_jobs import get_job
+        from dmguard.scheduler import claim_job
+
+        async with get_connection(db_path) as connection:
+            await connection.execute(
+                """
+                UPDATE jobs
+                SET updated_at = '2000-01-01T00:00:00Z'
+                WHERE job_id = ?
+                """,
+                (job_id,),
+            )
+            await connection.commit()
+
+        async with get_connection(db_path) as connection:
+            first_claim = await claim_job(connection, job_id)
+            second_claim = await claim_job(connection, job_id)
+            await connection.commit()
+            job = await get_job(connection, job_id)
+
+        return first_claim, second_claim, job
+
+    first_claim, second_claim, job = run(scenario())
+
+    assert first_claim is True
+    assert second_claim is False
+    assert job is not None
+    assert job["status"] == JobStatus.processing.value
+    assert job["attempt"] == 1
+    assert job["processing_started_at"] is not None
+    assert job["updated_at"] != "2000-01-01T00:00:00Z"
+
+
+def test_advance_stage_resets_attempt_and_updates_timestamp(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1"))
+    job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at="2026-03-11T00:00:00Z",
+            status=JobStatus.processing,
+            attempt=2,
+        )
+    )
+
+    async def scenario() -> tuple[bool, dict[str, object] | None]:
+        from dmguard.db import get_connection
+        from dmguard.repo_jobs import get_job
+        from dmguard.scheduler import advance_stage
+
+        async with get_connection(db_path) as connection:
+            await connection.execute(
+                """
+                UPDATE jobs
+                SET updated_at = '2000-01-01T00:00:00Z'
+                WHERE job_id = ?
+                """,
+                (job_id,),
+            )
+            await connection.commit()
+
+        async with get_connection(db_path) as connection:
+            advanced = await advance_stage(
+                connection,
+                job_id,
+                JobStage.download_media,
+            )
+            await connection.commit()
+            job = await get_job(connection, job_id)
+
+        return advanced, job
+
+    advanced, job = run(scenario())
+
+    assert advanced is True
+    assert job is not None
+    assert job["stage"] == JobStage.download_media.value
+    assert job["attempt"] == 0
+    assert job["updated_at"] != "2000-01-01T00:00:00Z"
+
+
+@pytest.mark.parametrize(
+    ("terminal_status"),
+    [
+        JobStatus.done,
+        JobStatus.error,
+        JobStatus.skipped,
+    ],
+)
+def test_complete_job_sets_terminal_status(
+    tmp_path: Path,
+    terminal_status: JobStatus,
+) -> None:
+    db_path = tmp_path / "state.db"
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1"))
+    job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at="2026-03-11T00:00:00Z",
+            status=JobStatus.processing,
+        )
+    )
+
+    async def scenario() -> tuple[bool, dict[str, object] | None]:
+        from dmguard.db import get_connection
+        from dmguard.repo_jobs import get_job
+        from dmguard.scheduler import complete_job
+
+        async with get_connection(db_path) as connection:
+            await connection.execute(
+                """
+                UPDATE jobs
+                SET updated_at = '2000-01-01T00:00:00Z'
+                WHERE job_id = ?
+                """,
+                (job_id,),
+            )
+            await connection.commit()
+
+        async with get_connection(db_path) as connection:
+            completed = await complete_job(connection, job_id, terminal_status)
+            await connection.commit()
+            job = await get_job(connection, job_id)
+
+        return completed, job
+
+    completed, job = run(scenario())
+
+    assert completed is True
+    assert job is not None
+    assert job["status"] == terminal_status.value
+    assert job["updated_at"] != "2000-01-01T00:00:00Z"
+
+
+def test_complete_job_rejects_non_terminal_status(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1"))
+    job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at="2026-03-11T00:00:00Z",
+            status=JobStatus.processing,
+        )
+    )
+
+    async def scenario() -> None:
+        from dmguard.db import get_connection
+        from dmguard.scheduler import complete_job
+
+        async with get_connection(db_path) as connection:
+            await complete_job(connection, job_id, JobStatus.processing)
+
+    with pytest.raises(ValueError, match="terminal"):
+        run(scenario())
 
 
 @pytest.mark.parametrize(

--- a/todo.md
+++ b/todo.md
@@ -153,7 +153,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] Queue overflow drops newest incoming job
 - [x] Queue overflow is tracked with counters only
 - [ ] Implement worker loop
-- [ ] Implement transactional claim/update logic
+- [x] Implement transactional claim/update logic
 - [x] Implement retry scheduling
 - [ ] Implement queue overflow counters
 - [x] Add scheduler tests


### PR DESCRIPTION
## Summary
- add a scheduler repository module for dequeue, claim, stage advance, and completion transitions
- cover the new scheduler behavior with dedicated SQLite-backed tests
- mark issue #9 and the verified scheduler checklist items as done

## Testing
- pytest tests/test_scheduler.py tests/test_repo.py tests/test_job_machine.py tests/test_db.py

Closes #9