### PR TITLE
ci(github): add repository workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12.12'
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - run: uv sync --locked --all-groups
+      - run: uv run ruff format --check .
+      - run: uv run ruff check .
+      - run: uv run pytest

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml"
+)
+
+
+def load_workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_ci_workflow_matches_repo_toolchain() -> None:
+    workflow = load_workflow()
+
+    assert workflow["name"] == "CI"
+    assert workflow["on"] == {
+        "pull_request": None,
+        "push": {"branches": ["main"]},
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress": True,
+    }
+
+    job = workflow["jobs"]["test"]
+    assert job["runs-on"] == "ubuntu-latest"
+
+    steps = job["steps"]
+    assert steps[0] == {"uses": "actions/checkout@v6"}
+    assert steps[1] == {
+        "uses": "actions/setup-python@v6",
+        "with": {"python-version": "3.12.12"},
+    }
+    assert steps[2] == {
+        "uses": "astral-sh/setup-uv@v7",
+        "with": {"enable-cache": True},
+    }
+    assert steps[3] == {"run": "uv sync --locked --all-groups"}
+    assert steps[4] == {"run": "uv run ruff format --check ."}
+    assert steps[5] == {"run": "uv run ruff check ."}
+    assert steps[6] == {"run": "uv run pytest"}


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for pull requests and pushes to main
- install the repo with uv on Python 3.12.12 and run Ruff plus pytest
- add a focused pytest contract test that verifies the workflow shape

## Testing
- uv run pytest tests/test_ci_workflow.py
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest

## Notes
- Closes #87.
- The full pytest run currently fails on a pre-existing regression in `dmguard/media_dispatch.py` introduced on `main` by commit `e0bb90c`; failure: `tests/test_media_dispatch.py::test_dispatch_media_logs_and_skips_unknown_types`.
