### PR TITLE
feat(classifier): add selftest CLI

### DIFF
--- a/dmguard/cli.py
+++ b/dmguard/cli.py
@@ -11,6 +11,7 @@ import sys
 import httpx
 import yaml
 
+from dmguard.classifier_contract import ClassifierResponse
 from dmguard.classifier_runner import run_classifier
 from dmguard.paths import CONFIG_PATH, PROGRAM_DATA_DIR, SECRETS_PATH
 from dmguard.setup_logger import SetupLogger
@@ -43,6 +44,13 @@ DEFAULT_WARMUP_CLASSIFIER_CMD = (
     "dmguard.classifier_fake",
     "--force-safe",
 )
+DEFAULT_SELFTEST_CLASSIFIER_MODULE = (
+    sys.executable,
+    "-m",
+    "dmguard.classifier_fake",
+)
+SELFTEST_POLICY = "violence_gore"
+SELFTEST_UNSAFE_THRESHOLD = 0.9
 SETUP_CONFIG_DEFAULTS = {
     "debug": False,
     "log_level": "INFO",
@@ -91,6 +99,14 @@ def build_parser() -> ArgumentParser:
     reset_parser = subparsers.add_parser("reset")
     reset_parser.add_argument("--force", action="store_true")
 
+    selftest_parser = subparsers.add_parser("selftest")
+    selftest_target_group = selftest_parser.add_mutually_exclusive_group(required=True)
+    selftest_target_group.add_argument("--image", type=Path)
+    selftest_target_group.add_argument("--video", type=Path)
+    selftest_force_group = selftest_parser.add_mutually_exclusive_group()
+    selftest_force_group.add_argument("--force-safe", action="store_true")
+    selftest_force_group.add_argument("--force-unsafe", action="store_true")
+
     subparsers.add_parser("warmup")
 
     status_parser = subparsers.add_parser("status")
@@ -112,6 +128,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return handle_setup(args)
         if args.command == "reset":
             return handle_reset(args)
+        if args.command == "selftest":
+            return handle_selftest(args)
         if args.command == "warmup":
             return handle_warmup()
         if args.command == "status":
@@ -241,6 +259,24 @@ def handle_status(args) -> int:
     return 0
 
 
+def handle_selftest(args) -> int:
+    mode, input_path = _resolve_selftest_target(args)
+
+    if not input_path.is_file():
+        raise ValueError(f"Input file not found: {input_path}")
+
+    response = run_classifier(
+        {
+            "mode": mode,
+            "files": [str(input_path)],
+            "policy": SELFTEST_POLICY,
+        },
+        _build_selftest_classifier_cmd(args),
+    )
+    print(_format_selftest_result(mode, input_path, response))
+    return 0
+
+
 def run_setup_warmup() -> dict[str, object]:
     response = run_classifier(
         {
@@ -297,6 +333,47 @@ def check_public_https_reachability(hostname: str) -> dict[str, object]:
         "status_code": response.status_code,
         "url": str(response.request.url),
     }
+
+
+def _resolve_selftest_target(args) -> tuple[str, Path]:
+    if args.image is not None:
+        return "image", args.image
+
+    if args.video is not None:
+        return "video", args.video
+
+    raise ValueError("either --image or --video is required")
+
+
+def _build_selftest_classifier_cmd(args) -> tuple[str, ...]:
+    classifier_cmd = list(DEFAULT_SELFTEST_CLASSIFIER_MODULE)
+
+    if args.force_safe:
+        classifier_cmd.append("--force-safe")
+    if args.force_unsafe:
+        classifier_cmd.append("--force-unsafe")
+
+    return tuple(classifier_cmd)
+
+
+def _format_selftest_result(
+    mode: str, input_path: Path, response: ClassifierResponse
+) -> str:
+    verdict = "unsafe" if response.yes_prob >= SELFTEST_UNSAFE_THRESHOLD else "safe"
+    output_lines = [
+        f"Result: {verdict}",
+        f"Policy: {response.policy}",
+        f"Score: {response.yes_prob:.2f}",
+        f"Mode: {mode}",
+        f"File: {input_path}",
+    ]
+
+    if response.trigger_frame_index is not None:
+        output_lines.append(f"Trigger frame: {response.trigger_frame_index}")
+    if response.trigger_time_sec is not None:
+        output_lines.append(f"Trigger time (s): {response.trigger_time_sec}")
+
+    return "\n".join(output_lines)
 
 
 def _load_or_create_setup_state() -> SetupState:

--- a/issues_todo.md
+++ b/issues_todo.md
@@ -60,7 +60,7 @@ GitHub repo: https://github.com/cgm-16/x-dm-moderator
 
 - [x] #25 Classifier subprocess contract + fake entrypoint — deps: #1
 - [x] #26 Subprocess runner + timeout — deps: #25
-- [ ] #27 Selftest CLI — deps: #26
+- [x] #27 Selftest CLI — deps: #26
 
 ## Milestone 9 — Moderation Engine
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,9 @@ def test_build_parser_recognizes_setup_subcommands() -> None:
 
     assert parser.parse_args(["setup"]).command == "setup"
     assert parser.parse_args(["reset", "--force"]).command == "reset"
+    assert (
+        parser.parse_args(["selftest", "--image", "sample.jpg"]).command == "selftest"
+    )
     assert parser.parse_args(["warmup"]).command == "warmup"
     assert parser.parse_args(["status"]).command == "status"
     assert parser.parse_args(["status", "--full"]).full is True
@@ -327,3 +330,104 @@ def test_warmup_invokes_setup_warmup(
         "policy": "violence_gore",
         "yes_prob": 0.01,
     }
+
+
+def test_selftest_force_safe_prints_safe_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    from dmguard import cli
+    from dmguard.classifier_contract import ClassifierResponse
+
+    image_path = tmp_path / "sample.jpg"
+    image_path.write_bytes(b"image")
+    calls: list[tuple[dict[str, object], tuple[str, ...]]] = []
+
+    def fake_run_classifier(
+        input_data: dict[str, object], classifier_cmd: tuple[str, ...]
+    ) -> ClassifierResponse:
+        calls.append((input_data, classifier_cmd))
+        return ClassifierResponse(policy="violence_gore", yes_prob=0.01)
+
+    monkeypatch.setattr(cli, "run_classifier", fake_run_classifier)
+
+    exit_code = cli.main(["selftest", "--image", str(image_path), "--force-safe"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "safe" in captured.out.lower()
+    assert "0.01" in captured.out
+    assert calls == [
+        (
+            {
+                "mode": "image",
+                "files": [str(image_path)],
+                "policy": "violence_gore",
+            },
+            (
+                cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[0],
+                cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[1],
+                cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[2],
+                "--force-safe",
+            ),
+        )
+    ]
+
+
+def test_selftest_force_unsafe_video_prints_trigger_info(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    from dmguard import cli
+    from dmguard.classifier_contract import ClassifierResponse
+
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"video")
+
+    def fake_run_classifier(
+        input_data: dict[str, object], classifier_cmd: tuple[str, ...]
+    ) -> ClassifierResponse:
+        assert input_data == {
+            "mode": "video",
+            "files": [str(video_path)],
+            "policy": "violence_gore",
+        }
+        assert classifier_cmd == (
+            cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[0],
+            cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[1],
+            cli.DEFAULT_SELFTEST_CLASSIFIER_MODULE[2],
+            "--force-unsafe",
+        )
+        return ClassifierResponse(
+            policy="violence_gore",
+            yes_prob=0.99,
+            trigger_frame_index=0,
+            trigger_time_sec=1.0,
+        )
+
+    monkeypatch.setattr(cli, "run_classifier", fake_run_classifier)
+
+    exit_code = cli.main(["selftest", "--video", str(video_path), "--force-unsafe"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "unsafe" in captured.out.lower()
+    assert "trigger" in captured.out.lower()
+    assert "0" in captured.out
+    assert "1.0" in captured.out
+
+
+def test_selftest_invalid_path_fails_with_clear_error_message(
+    tmp_path: Path, capsys
+) -> None:
+    from dmguard import cli
+
+    missing_path = tmp_path / "missing.jpg"
+
+    exit_code = cli.main(["selftest", "--image", str(missing_path)])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "not found" in captured.err.lower()
+    assert str(missing_path) in captured.err

--- a/todo.md
+++ b/todo.md
@@ -222,7 +222,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] Implement subprocess contract
 - [x] Implement fake classifier mode for early tests
 - [ ] Integrate real ShieldGemma inference
-- [ ] Implement selftest CLI
+- [x] Implement selftest CLI
 - [x] Add classifier contract tests
 
 ---
@@ -350,7 +350,7 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] `readycheck`
 - [ ] Implement allowlist add/remove
 - [ ] Implement blockstate remove
-- [ ] Implement selftest
+- [x] Implement selftest
 - [ ] Implement readycheck
 - [ ] Add CLI tests
 


### PR DESCRIPTION
## Summary
- add the `dmguard selftest` subcommand for image and video inputs
- print human-readable selftest results and surface invalid-path errors
- add focused CLI coverage and mark issue #27 complete in backlog tracking

## Testing
- uv run pytest tests/test_cli.py tests/test_classifier_fake.py tests/test_classifier_runner.py
- uv run ruff check dmguard/cli.py tests/test_cli.py

Closes #27