### PR TITLE
feat(audit): add redacted job error recording

### DIFF
--- a/dmguard/repo_audit.py
+++ b/dmguard/repo_audit.py
@@ -1,5 +1,7 @@
 import aiosqlite
 
+from dmguard.setup_logger import redact_secrets
+
 
 async def append_audit_row(
     connection: aiosqlite.Connection,
@@ -49,7 +51,7 @@ async def append_audit_row(
     return int(cursor.lastrowid)
 
 
-async def insert_job_error(
+async def record_job_error(
     connection: aiosqlite.Connection,
     *,
     job_id: int,
@@ -59,6 +61,10 @@ async def insert_job_error(
     error_message: str | None,
     http_status: int | None,
 ) -> int:
+    redacted_error_message = None
+    if error_message is not None:
+        redacted_error_message = redact_secrets(error_message)
+
     cursor = await connection.execute(
         """
         INSERT INTO job_errors (
@@ -71,11 +77,18 @@ async def insert_job_error(
         )
         VALUES (?, ?, ?, ?, ?, ?)
         """,
-        (job_id, stage, attempt, error_type, error_message, http_status),
+        (
+            job_id,
+            stage,
+            attempt,
+            error_type,
+            redacted_error_message,
+            http_status,
+        ),
     )
 
     await cursor.close()
     return int(cursor.lastrowid)
 
 
-__all__ = ["append_audit_row", "insert_job_error"]
+__all__ = ["append_audit_row", "record_job_error"]

--- a/dmguard/setup_logger.py
+++ b/dmguard/setup_logger.py
@@ -36,12 +36,16 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
 )
 
 
+def redact_secrets(message: str) -> str:
+    return SECRET_ASSIGNMENT_PATTERN.sub(_replace_secret_value, message)
+
+
 @dataclass(frozen=True)
 class SetupLogger:
     path: Path = DEFAULT_SETUP_LOG_PATH
 
     def redact(self, message: str) -> str:
-        return SECRET_ASSIGNMENT_PATTERN.sub(self._replace_secret_value, message)
+        return redact_secrets(message)
 
     def log(self, message: str) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -52,10 +56,10 @@ class SetupLogger:
         with self.path.open("a", encoding="utf-8") as log_file:
             log_file.write(line)
 
-    @staticmethod
-    def _replace_secret_value(match: re.Match[str]) -> str:
-        quote = match.group("quote")
-        return f"{match.group('label')}{quote}[REDACTED]{quote}"
+
+def _replace_secret_value(match: re.Match[str]) -> str:
+    quote = match.group("quote")
+    return f"{match.group('label')}{quote}[REDACTED]{quote}"
 
 
-__all__ = ["DEFAULT_SETUP_LOG_PATH", "SetupLogger"]
+__all__ = ["DEFAULT_SETUP_LOG_PATH", "SetupLogger", "redact_secrets"]

--- a/tests/test_pruner.py
+++ b/tests/test_pruner.py
@@ -81,7 +81,7 @@ def test_prune_old_data_deletes_old_terminal_history_in_order(tmp_path: Path) ->
     async def scenario():
         from dmguard.db import get_connection
         from dmguard.job_machine import JobStage, JobStatus
-        from dmguard.repo_audit import append_audit_row, insert_job_error
+        from dmguard.repo_audit import append_audit_row, record_job_error
         from dmguard.repo_events import insert_event
         from dmguard.repo_jobs import insert_job, update_job_status
         from dmguard.repo_rejected import insert_rejected_request
@@ -114,7 +114,7 @@ def test_prune_old_data_deletes_old_terminal_history_in_order(tmp_path: Path) ->
                 ("2000-01-01 00:00:00", job_id),
             )
 
-            error_id = await insert_job_error(
+            error_id = await record_job_error(
                 connection,
                 job_id=job_id,
                 stage=JobStage.fetch_dm.value,
@@ -345,7 +345,7 @@ def test_prune_old_data_keeps_recent_terminal_history(tmp_path: Path) -> None:
     async def scenario():
         from dmguard.db import get_connection
         from dmguard.job_machine import JobStage, JobStatus
-        from dmguard.repo_audit import append_audit_row, insert_job_error
+        from dmguard.repo_audit import append_audit_row, record_job_error
         from dmguard.repo_events import insert_event
         from dmguard.repo_jobs import insert_job, update_job_status
         from dmguard.pruner import PruneResult, prune_old_data
@@ -372,7 +372,7 @@ def test_prune_old_data_keeps_recent_terminal_history(tmp_path: Path) -> None:
                 status=JobStatus.error,
                 stage=JobStage.fetch_dm,
             )
-            await insert_job_error(
+            await record_job_error(
                 connection,
                 job_id=job_id,
                 stage=JobStage.fetch_dm.value,

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -19,6 +19,18 @@ async def fetch_row(
     return row
 
 
+async def fetch_all_rows(
+    db_path: Path, query: str, params: tuple[object, ...] = ()
+) -> list[tuple]:
+    from dmguard.db import get_connection
+
+    async with get_connection(db_path) as connection:
+        cursor = await connection.execute(query, params)
+        rows = await cursor.fetchall()
+
+    return rows
+
+
 def test_repo_events_insert_and_get(tmp_path: Path) -> None:
     db_path = tmp_path / "state.db"
 
@@ -372,7 +384,7 @@ def test_repo_audit_rejected_and_kv_write_expected_rows(tmp_path: Path) -> None:
 
     async def scenario() -> tuple[int, int, str | None]:
         from dmguard.db import get_connection
-        from dmguard.repo_audit import append_audit_row, insert_job_error
+        from dmguard.repo_audit import append_audit_row, record_job_error
         from dmguard.repo_kv import kv_get, kv_set
         from dmguard.repo_rejected import insert_rejected_request
 
@@ -390,13 +402,16 @@ def test_repo_audit_rejected_and_kv_write_expected_rows(tmp_path: Path) -> None:
                 trigger_time_sec=None,
                 block_attempted=False,
             )
-            error_id = await insert_job_error(
+            error_id = await record_job_error(
                 connection,
                 job_id=job_id,
                 stage=JobStage.fetch_dm.value,
                 attempt=1,
                 error_type="network",
-                error_message="boom",
+                error_message=(
+                    "authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig "
+                    'x_access_token=access-token password="hunter2"'
+                ),
                 http_status=500,
             )
             await insert_rejected_request(
@@ -473,8 +488,76 @@ def test_repo_audit_rejected_and_kv_write_expected_rows(tmp_path: Path) -> None:
         JobStage.fetch_dm.value,
         1,
         "network",
-        "boom",
+        'authorization: [REDACTED] x_access_token=[REDACTED] password="[REDACTED]"',
         500,
     )
     assert rejected_row == ("127.0.0.1", "/webhooks/x", "invalid_json", "abc123")
     assert kv_value == "2026-03-13T00:00:00Z"
+
+
+def test_repo_audit_allows_multiple_rows_per_job(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    run(bootstrap_database(db_path))
+    run(insert_event_row(db_path, event_id="event-1", sender_id="sender-1"))
+    job_id = run(
+        insert_job_row(
+            db_path,
+            event_id="event-1",
+            next_run_at="2026-03-11T00:00:00Z",
+        )
+    )
+
+    async def scenario() -> list[tuple[int, str]]:
+        from dmguard.db import get_connection
+        from dmguard.repo_audit import append_audit_row
+
+        async with get_connection(db_path) as connection:
+            await append_audit_row(
+                connection,
+                job_id=job_id,
+                event_id="event-1",
+                sender_id="sender-1",
+                outcome="safe",
+                policy="O2_violence_harm_cruelty",
+                category_code="NA: None applying",
+                rationale="All frames safe",
+                trigger_frame_index=None,
+                trigger_time_sec=None,
+                block_attempted=False,
+            )
+            await append_audit_row(
+                connection,
+                job_id=job_id,
+                event_id="event-1",
+                sender_id="sender-1",
+                outcome="error",
+                policy="O2_violence_harm_cruelty",
+                category_code=None,
+                rationale=None,
+                trigger_frame_index=None,
+                trigger_time_sec=None,
+                block_attempted=False,
+            )
+            await connection.commit()
+
+        return [
+            tuple(row)
+            for row in await fetch_all_rows(
+                db_path,
+                """
+                SELECT job_id, outcome
+                FROM moderation_audit
+                WHERE job_id = ?
+                ORDER BY id ASC
+                """,
+                (job_id,),
+            )
+        ]
+
+    rows = run(scenario())
+
+    assert rows == [
+        (job_id, "safe"),
+        (job_id, "error"),
+    ]

--- a/todo.md
+++ b/todo.md
@@ -260,10 +260,10 @@ Project: X DM Image Safety Filter Prototype (v0.1)
 - [x] MVP behavior appends one final audit row per job
 - [x] `moderation_audit` retention = 30 days
 - [x] `moderation_audit` index = `created_at` only
-- [ ] Implement `job_errors`
-- [ ] Implement `moderation_audit`
+- [x] Implement `job_errors`
+- [x] Implement `moderation_audit`
 - [ ] Write final audit row on terminal job outcome
-- [ ] Add audit and error history tests
+- [x] Add audit and error history tests
 
 ---
 


### PR DESCRIPTION
## Summary
- rename the job error insert helper to `record_job_error`
- redact secret-shaped values before storing `job_errors.error_message`
- add repository coverage for redaction and multiple audit rows per job

## Testing
- `uv run pytest tests/test_repo.py tests/test_pruner.py tests/test_setup_logger.py -q`

Closes #31