### PR TITLE
fix(x-client): harden retry-after and auth headers

### DIFF
--- a/dmguard/x_client.py
+++ b/dmguard/x_client.py
@@ -84,6 +84,7 @@ class XClient:
         **kwargs: object,
     ) -> httpx.Response:
         request_kwargs = dict(kwargs)
+        # Caller-supplied Authorization is intentionally overridden.
         headers = httpx.Headers(request_kwargs.get("headers"))
         headers["Authorization"] = f"Bearer {self._secret_store.get('x_access_token')}"
         request_kwargs["headers"] = headers

--- a/dmguard/x_client.py
+++ b/dmguard/x_client.py
@@ -3,6 +3,8 @@ import httpx
 from dmguard.secrets import SecretStore
 from dmguard.x_oauth import async_refresh_access_token
 
+DEFAULT_RETRY_AFTER_SECONDS = 1
+
 
 class RateLimitedError(Exception):
     def __init__(self, retry_after_seconds: int) -> None:
@@ -29,7 +31,6 @@ class XClient:
         self._secret_store = secret_store
         self._client = httpx.AsyncClient(
             base_url=base_url,
-            headers={"Authorization": f"Bearer {secret_store.get('x_access_token')}"},
             timeout=timeout_seconds,
             transport=transport,
         )
@@ -48,7 +49,7 @@ class XClient:
         await self._client.aclose()
 
     async def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
-        response = await self._client.request(method, url, **kwargs)
+        response = await self._request_with_current_token(method, url, **kwargs)
 
         if response.status_code == 429:
             raise RateLimitedError(_parse_retry_after(response))
@@ -56,7 +57,7 @@ class XClient:
         # Single-worker architecture: no guard against concurrent refresh races.
         if response.status_code == 401:
             await self._refresh_token()
-            response = await self._client.request(method, url, **kwargs)
+            response = await self._request_with_current_token(method, url, **kwargs)
             if response.status_code == 429:
                 raise RateLimitedError(_parse_retry_after(response))
 
@@ -73,9 +74,20 @@ class XClient:
             tokens = await async_refresh_access_token(client_id, old_refresh_token)
             self._secret_store.update("x_access_token", tokens["access_token"])
             self._secret_store.update("x_refresh_token", tokens["refresh_token"])
-            self._client.headers["Authorization"] = f"Bearer {tokens['access_token']}"
         except Exception as exc:
             raise XApiError(401, f"Token refresh failed: {exc}") from exc
+
+    async def _request_with_current_token(
+        self,
+        method: str,
+        url: str,
+        **kwargs: object,
+    ) -> httpx.Response:
+        request_kwargs = dict(kwargs)
+        headers = httpx.Headers(request_kwargs.get("headers"))
+        headers["Authorization"] = f"Bearer {self._secret_store.get('x_access_token')}"
+        request_kwargs["headers"] = headers
+        return await self._client.request(method, url, **request_kwargs)
 
     async def get(self, url: str, **kwargs: object) -> httpx.Response:
         return await self.request("GET", url, **kwargs)
@@ -88,12 +100,14 @@ class XClient:
 
 
 def _parse_retry_after(response: httpx.Response) -> int:
-    retry_after = response.headers.get("Retry-After", "0")
+    retry_after = response.headers.get("Retry-After")
 
     try:
-        return int(retry_after)
-    except ValueError:
-        return 0
+        retry_after_seconds = int(retry_after)
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_AFTER_SECONDS
+
+    return max(retry_after_seconds, DEFAULT_RETRY_AFTER_SECONDS)
 
 
 __all__ = ["RateLimitedError", "XApiError", "XClient"]

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -62,6 +62,38 @@ def test_x_client_raises_rate_limited_error_on_429() -> None:
     assert exc_info.value.retry_after_seconds == 17
 
 
+@pytest.mark.parametrize(
+    ("retry_after_header",),
+    [
+        (None,),
+        ("not-a-number",),
+        ("0",),
+    ],
+)
+def test_x_client_uses_minimum_rate_limit_delay_for_invalid_retry_after(
+    retry_after_header: str | None,
+) -> None:
+    from dmguard.x_client import RateLimitedError, XClient
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        headers = {}
+        if retry_after_header is not None:
+            headers["Retry-After"] = retry_after_header
+        return httpx.Response(429, headers=headers)
+
+    async def perform_request() -> None:
+        async with XClient(
+            StubSecretStore(x_access_token="access-token"),
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await client.get("/2/test")
+
+    with pytest.raises(RateLimitedError) as exc_info:
+        run(perform_request())
+
+    assert exc_info.value.retry_after_seconds == 1
+
+
 def test_x_client_raises_api_error_on_other_non_success_statuses() -> None:
     from dmguard.x_client import XApiError, XClient
 
@@ -82,6 +114,26 @@ def test_x_client_raises_api_error_on_other_non_success_statuses() -> None:
     assert exc_info.value.body == '{"error":"bad"}'
 
 
+def test_x_client_reads_access_token_for_each_request() -> None:
+    from dmguard.x_client import XClient
+
+    store = StubSecretStore(x_access_token="old-token")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer new-token"
+        return httpx.Response(200, text="ok")
+
+    async def perform_request() -> str:
+        async with XClient(store, transport=httpx.MockTransport(handler)) as client:
+            store.update("x_access_token", "new-token")
+            response = await client.get("/2/test")
+            return response.text
+
+    result = run(perform_request())
+
+    assert result == "ok"
+
+
 def test_refreshes_token_on_401_and_retries() -> None:
     from dmguard.x_client import XClient
 
@@ -91,7 +143,9 @@ def test_refreshes_token_on_401_and_retries() -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
+            assert request.headers["Authorization"] == "Bearer old-token"
             return httpx.Response(401, text="Unauthorized")
+        assert request.headers["Authorization"] == "Bearer new-token"
         return httpx.Response(200, text="ok")
 
     store = StubSecretStore(


### PR DESCRIPTION
## Summary
- make XClient apply the bearer token per request instead of freezing it in client default headers
- make Retry-After parsing fall back to a minimum positive delay when the header is missing, invalid, or zero
- add regression coverage for invalid Retry-After handling and refreshed-token retry behavior

## Testing
- uv run pytest tests/test_x_client.py tests/test_x_dm.py tests/test_media_download.py

Closes #60