### PR TITLE
fix(paths): require non-Windows path overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ uv sync --locked --all-groups
 
 ### Local path setup on macOS/Linux
 
-The default paths target the Windows install layout. For local work on macOS/Linux, point the app at local writable directories first:
+The default paths target the Windows install layout. For local work on macOS/Linux, you must point the app at local writable directories first. Commands fail clearly until both env vars are set:
 
 ```bash
 export DMGUARD_APP_ROOT="$PWD/.dmguard/app"

--- a/dmguard/paths.py
+++ b/dmguard/paths.py
@@ -7,6 +7,8 @@ import sys
 
 WINDOWS_PROGRAM_FILES_DIR = Path("C:/Program Files/XDMModerator")
 WINDOWS_PROGRAM_DATA_DIR = Path("C:/ProgramData/XDMModerator")
+NON_WINDOWS_APP_ROOT_ENV = "DMGUARD_APP_ROOT"
+NON_WINDOWS_DATA_ROOT_ENV = "DMGUARD_DATA_ROOT"
 
 
 @dataclass(frozen=True)
@@ -20,26 +22,40 @@ class ResolvedPaths:
     tmp_dir: Path
 
 
+def _resolve_non_windows_roots(env: Mapping[str, str]) -> tuple[Path, Path]:
+    app_root = env.get(NON_WINDOWS_APP_ROOT_ENV)
+    data_root = env.get(NON_WINDOWS_DATA_ROOT_ENV)
+    missing = []
+
+    if not app_root:
+        missing.append(NON_WINDOWS_APP_ROOT_ENV)
+
+    if not data_root:
+        missing.append(NON_WINDOWS_DATA_ROOT_ENV)
+
+    if missing:
+        raise ValueError(
+            "Non-Windows path resolution requires "
+            f"{NON_WINDOWS_APP_ROOT_ENV} and {NON_WINDOWS_DATA_ROOT_ENV}; "
+            f"missing: {', '.join(missing)}"
+        )
+
+    return Path(app_root), Path(data_root)
+
+
 def resolve_paths(
     *,
     platform: str | None = None,
     env: Mapping[str, str] | None = None,
 ) -> ResolvedPaths:
     current_platform = platform or sys.platform
-    current_env = env or os.environ
+    current_env = os.environ if env is None else env
 
-    program_files_dir = WINDOWS_PROGRAM_FILES_DIR
-    program_data_dir = WINDOWS_PROGRAM_DATA_DIR
-
-    if not current_platform.startswith("win"):
-        app_root = current_env.get("DMGUARD_APP_ROOT")
-        data_root = current_env.get("DMGUARD_DATA_ROOT")
-
-        if app_root:
-            program_files_dir = Path(app_root)
-
-        if data_root:
-            program_data_dir = Path(data_root)
+    if current_platform.startswith("win"):
+        program_files_dir = WINDOWS_PROGRAM_FILES_DIR
+        program_data_dir = WINDOWS_PROGRAM_DATA_DIR
+    else:
+        program_files_dir, program_data_dir = _resolve_non_windows_roots(current_env)
 
     return ResolvedPaths(
         program_files_dir=program_files_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from tempfile import gettempdir
 
 if not sys.platform.startswith("win"):
     # Keep pytest collection self-contained when dmguard.paths fails fast on non-Windows.
+    # Must run before any dmguard import (secrets.py imports paths at the top level).
     os.environ.setdefault(
         "DMGUARD_APP_ROOT",
         str(Path(gettempdir()) / "dmguard-test-app"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,21 @@ import base64
 import hashlib
 import hmac
 import logging
+import os
 from pathlib import Path
+import sys
+from tempfile import gettempdir
+
+if not sys.platform.startswith("win"):
+    # Keep pytest collection self-contained when dmguard.paths fails fast on non-Windows.
+    os.environ.setdefault(
+        "DMGUARD_APP_ROOT",
+        str(Path(gettempdir()) / "dmguard-test-app"),
+    )
+    os.environ.setdefault(
+        "DMGUARD_DATA_ROOT",
+        str(Path(gettempdir()) / "dmguard-test-data"),
+    )
 
 from dmguard.job_machine import JobStage, JobStatus
 from dmguard.secrets import SecretStore

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -54,7 +54,7 @@ def test_generate_traefik_service_def_contains_required_servy_fields() -> None:
     service_def = edge.generate_traefik_service_def()
 
     assert service_def == {
-        "name": edge.TRAEFIK_SERVICE_NAME,
+        "name": "XDMModeratorTraefik",
         "displayName": "XDMModerator Traefik",
         "description": "Traefik reverse proxy for XDMModerator",
         "path": str(edge.TRAEFIK_BINARY_PATH),
@@ -72,7 +72,7 @@ def test_generate_dmguard_service_def_contains_dependency_on_traefik() -> None:
     service_def = edge.generate_dmguard_service_def()
 
     assert service_def == {
-        "name": edge.DMGUARD_SERVICE_NAME,
+        "name": "XDMModerator",
         "displayName": "XDMModerator",
         "description": "XDMModerator application service",
         "path": str(edge.DMGUARD_PYTHON_PATH),
@@ -81,5 +81,5 @@ def test_generate_dmguard_service_def_contains_dependency_on_traefik() -> None:
         "startupType": "Automatic",
         "stdout": str(edge.LOGS_DIR / "dmguard-service.out.log"),
         "stderr": str(edge.LOGS_DIR / "dmguard-service.err.log"),
-        "deps": [edge.TRAEFIK_SERVICE_NAME],
+        "deps": ["XDMModeratorTraefik"],
     }

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -49,37 +49,37 @@ def test_write_routes_atomically_rejects_non_mapping_yaml(tmp_path: Path) -> Non
 
 
 def test_generate_traefik_service_def_contains_required_servy_fields() -> None:
-    from dmguard.edge import generate_traefik_service_def
+    from dmguard import edge
 
-    service_def = generate_traefik_service_def()
+    service_def = edge.generate_traefik_service_def()
 
     assert service_def == {
-        "name": "XDMModeratorTraefik",
+        "name": edge.TRAEFIK_SERVICE_NAME,
         "displayName": "XDMModerator Traefik",
         "description": "Traefik reverse proxy for XDMModerator",
-        "path": "C:/Program Files/XDMModerator/traefik/traefik.exe",
-        "startupDir": "C:/Program Files/XDMModerator/traefik",
-        "params": "--configFile=C:/ProgramData/XDMModerator/traefik/traefik-static.yml",
+        "path": str(edge.TRAEFIK_BINARY_PATH),
+        "startupDir": str(edge.TRAEFIK_STARTUP_DIR),
+        "params": f"--configFile={edge.TRAEFIK_STATIC_CONFIG_PATH}",
         "startupType": "Automatic",
-        "stdout": "C:/ProgramData/XDMModerator/logs/traefik-service.out.log",
-        "stderr": "C:/ProgramData/XDMModerator/logs/traefik-service.err.log",
+        "stdout": str(edge.LOGS_DIR / "traefik-service.out.log"),
+        "stderr": str(edge.LOGS_DIR / "traefik-service.err.log"),
     }
 
 
 def test_generate_dmguard_service_def_contains_dependency_on_traefik() -> None:
-    from dmguard.edge import generate_dmguard_service_def
+    from dmguard import edge
 
-    service_def = generate_dmguard_service_def()
+    service_def = edge.generate_dmguard_service_def()
 
     assert service_def == {
-        "name": "XDMModerator",
+        "name": edge.DMGUARD_SERVICE_NAME,
         "displayName": "XDMModerator",
         "description": "XDMModerator application service",
-        "path": "C:/Program Files/XDMModerator/.venv/Scripts/python.exe",
+        "path": str(edge.DMGUARD_PYTHON_PATH),
         "params": "-m dmguard",
-        "startupDir": "C:/Program Files/XDMModerator",
+        "startupDir": str(edge.PROGRAM_FILES_DIR),
         "startupType": "Automatic",
-        "stdout": "C:/ProgramData/XDMModerator/logs/dmguard-service.out.log",
-        "stderr": "C:/ProgramData/XDMModerator/logs/dmguard-service.err.log",
-        "deps": ["XDMModeratorTraefik"],
+        "stdout": str(edge.LOGS_DIR / "dmguard-service.out.log"),
+        "stderr": str(edge.LOGS_DIR / "dmguard-service.err.log"),
+        "deps": [edge.TRAEFIK_SERVICE_NAME],
     }

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,5 +1,10 @@
 import importlib
+import os
 from pathlib import Path
+import subprocess
+import sys
+
+import pytest
 
 
 def test_resolve_paths_windows_defaults():
@@ -34,6 +39,48 @@ def test_resolve_paths_non_windows_env_override():
     assert paths.secrets_path == Path("/tmp/dmguard-data/secrets.bin")
     assert paths.logs_dir == Path("/tmp/dmguard-data/logs")
     assert paths.tmp_dir == Path("/tmp/dmguard-data/tmp")
+
+
+def test_resolve_paths_non_windows_requires_both_env_vars():
+    from dmguard.paths import resolve_paths
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_paths(platform="darwin", env={})
+
+    assert str(exc_info.value) == (
+        "Non-Windows path resolution requires DMGUARD_APP_ROOT and "
+        "DMGUARD_DATA_ROOT; missing: DMGUARD_APP_ROOT, DMGUARD_DATA_ROOT"
+    )
+
+
+def test_resolve_paths_non_windows_requires_app_root():
+    from dmguard.paths import resolve_paths
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_paths(
+            platform="darwin",
+            env={"DMGUARD_DATA_ROOT": "/tmp/dmguard-data"},
+        )
+
+    assert str(exc_info.value) == (
+        "Non-Windows path resolution requires DMGUARD_APP_ROOT and "
+        "DMGUARD_DATA_ROOT; missing: DMGUARD_APP_ROOT"
+    )
+
+
+def test_resolve_paths_non_windows_requires_data_root():
+    from dmguard.paths import resolve_paths
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_paths(
+            platform="darwin",
+            env={"DMGUARD_APP_ROOT": "/tmp/dmguard-app"},
+        )
+
+    assert str(exc_info.value) == (
+        "Non-Windows path resolution requires DMGUARD_APP_ROOT and "
+        "DMGUARD_DATA_ROOT; missing: DMGUARD_DATA_ROOT"
+    )
 
 
 def test_resolved_paths_are_path_instances():
@@ -81,3 +128,27 @@ def test_exported_path_constants_respect_non_windows_env_override(monkeypatch):
         assert reloaded_paths.TMP_DIR == Path("/tmp/dmguard-data/tmp")
 
     importlib.reload(paths)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="non-Windows only")
+def test_importing_paths_without_non_windows_env_vars_fails_clearly(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"DMGUARD_APP_ROOT", "DMGUARD_DATA_ROOT"}
+    }
+    env["PYTHONPATH"] = str(repo_root)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import dmguard.paths"],
+        capture_output=True,
+        check=False,
+        cwd=repo_root,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "DMGUARD_APP_ROOT" in result.stderr
+    assert "DMGUARD_DATA_ROOT" in result.stderr

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -131,7 +131,7 @@ def test_exported_path_constants_respect_non_windows_env_override(monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="non-Windows only")
-def test_importing_paths_without_non_windows_env_vars_fails_clearly(tmp_path: Path):
+def test_importing_paths_without_non_windows_env_vars_fails_clearly():
     repo_root = Path(__file__).resolve().parents[1]
     env = {
         key: value

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -6,7 +6,7 @@ import pytest
 def test_install_service_builds_expected_servy_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from dmguard.edge import generate_dmguard_service_def
+    from dmguard import edge
     from dmguard import service_manager
 
     recorded: list[list[str]] = []
@@ -27,7 +27,8 @@ def test_install_service_builds_expected_servy_command(
     monkeypatch.setattr(service_manager.sys, "platform", "win32")
     monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
 
-    service_manager.install_service(generate_dmguard_service_def())
+    definition = edge.generate_dmguard_service_def()
+    service_manager.install_service(definition)
 
     assert recorded == [
         [
@@ -35,23 +36,23 @@ def test_install_service_builds_expected_servy_command(
             "install",
             "--quiet",
             "--name",
-            "XDMModerator",
+            str(definition["name"]),
             "--displayName",
-            "XDMModerator",
+            str(definition["displayName"]),
             "--description",
-            "XDMModerator application service",
+            str(definition["description"]),
             "--path",
-            "C:/Program Files/XDMModerator/.venv/Scripts/python.exe",
+            str(definition["path"]),
             "--startupDir",
-            "C:/Program Files/XDMModerator",
+            str(definition["startupDir"]),
             "--startupType",
-            "Automatic",
+            str(definition["startupType"]),
             "--stdout",
-            "C:/ProgramData/XDMModerator/logs/dmguard-service.out.log",
+            str(definition["stdout"]),
             "--stderr",
-            "C:/ProgramData/XDMModerator/logs/dmguard-service.err.log",
-            "--params=-m dmguard",
-            "--deps=XDMModeratorTraefik",
+            str(definition["stderr"]),
+            f"--params={definition['params']}",
+            f"--deps={'; '.join(str(dep) for dep in definition['deps'])}",
         ]
     ]
 


### PR DESCRIPTION
## Summary
- fail fast on non-Windows when DMGUARD_APP_ROOT or DMGUARD_DATA_ROOT is missing
- keep pytest self-contained on non-Windows and add regression coverage for the import-time failure
- update README wording and align service-definition tests with resolved path constants

## Testing
- uv run pytest tests/test_paths.py tests/test_cli.py -q
- uv run pytest
- uv run ruff check .
- uv run ruff format --check .

Closes #57